### PR TITLE
Use failwith instead of Lwt.fail_with

### DIFF
--- a/mirage-nat/unikernel.ml
+++ b/mirage-nat/unikernel.ml
@@ -37,10 +37,10 @@ struct
   let start _ _ _ _ s net eth arp _ip data =
     let private_ip_cidr = Key_gen.private_ipv4 () in
     read_config data >>= function
-    | Error (`Msg m) -> Lwt.fail_with m
+    | Error (`Msg m) -> failwith m
     | Ok config -> (
         O.connect config s >>= function
-        | Error (`Msg m) -> Lwt.fail_with m
+        | Error (`Msg m) -> failwith m
         | Ok ovpn ->
             Logs.info (fun m -> m "tunnel established");
             let output_tunnel packet =

--- a/mirage-server/unikernel.ml
+++ b/mirage-server/unikernel.ml
@@ -21,7 +21,7 @@ struct
     read_config data >>= function
     | Error (`Msg msg) ->
         Logs.err (fun m -> m "error while reading config %s" msg);
-        Lwt.fail_with "config file error"
+        failwith "config file error"
     | Ok config ->
         let _t = O.connect config s in
         let task, _u = Lwt.task () in

--- a/mirage/miragevpn_mirage.ml
+++ b/mirage/miragevpn_mirage.ml
@@ -448,7 +448,7 @@ struct
             Log.err (fun m -> m "disconnecting flow %a:%d" Ipaddr.pp ip port);
             conn.peer <- None;
             TCP.close f)
-    | `Exit -> Lwt.fail_with "exit called"
+    | `Exit -> failwith "exit called"
     | `Payload data -> Lwt_mvar.put conn.data_mvar data
     | `Established (ip, mtu) ->
         Log.debug (fun m -> m "action = established");


### PR DESCRIPTION
`Lwt.fail` and `Lwt.fail_with` do not produce nice stack traces, and in most cases directly raising the exception (or using `failwith`) is preferable. The exceptions here are not very interesting and should perhaps be replaced by printf/log message followed by `exit N`.