### PR TITLE
Add support for --tls-cipher and --tls-ciphersuite

### DIFF
--- a/src/miragevpn.mli
+++ b/src/miragevpn.mli
@@ -181,9 +181,13 @@ module Config : sig
     (** Retransmit control channel packet after not receiving an ACK for
         [n] seconds. TODO: presumably does not apply to TCP? *)
 
-    | Tls_version_min : ([`V1_3 | `V1_2 | `V1_1 ] * bool) k
+    | Tls_version_min : (Tls.Core.tls_version * bool) k
     (** [v * or_highest]: if [or_highest] then v = the highest version supported
         by the TLS library. *)
+
+    | Tls_cipher : Tls.Ciphersuite.ciphersuite list k
+
+    | Tls_ciphersuite : Tls.Ciphersuite.ciphersuite13 list k
 
     | Topology : [`Net30 | `P2p | `Subnet] k
 

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -488,6 +488,12 @@ let tls_home_conf =
   |> add_b (a_key_payload (string_of_file "client.key"))
   |> add Cipher "AES-256-CBC" |> add Verb 3
 
+let tls_home_conf_with_cipher =
+  let open Miragevpn.Config in
+  tls_home_conf
+  |> add Tls_cipher [ `ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 ]
+  |> add Tls_ciphersuite [ `CHACHA20_POLY1305_SHA256 ]
+
 let ipredator_conf =
   let ca =
     match
@@ -575,7 +581,7 @@ efabaa5e34619f13adbe58b6c83536d3
   |> add Replay_window (512, 60)
   |> add Mute_replay_warnings ()
   |> add Ifconfig_nowarn ()
-  |> add Tls_version_min (`V1_2, false)
+  |> add Tls_version_min (`TLS_1_2, false)
 
 let parse_multiple_cas () =
   let file = "multi-ca-client.conf" in
@@ -633,7 +639,10 @@ let tests =
       parse_multiple_cas );
     (* "parsing configuration 'wild-client'", `Quick,
        parse_client_configuration "wild-client.conf" ; -- verify-x509-name *)
-    (* "parsing configuration 'windows-riseup-client'", `Quick,
-       parse_client_configuration "windows-riseup-client.conf" ; -- tls-cipher *)
+    (* ( "parsing configuration 'windows-riseup-client'", `Quick,
+       parse_client_configuration "windows-riseup-client.conf" ); --auth *)
+    ( "parsing 'tls-home-with-cipher'",
+      `Quick,
+      parse_client_configuration ~config:tls_home_conf_with_cipher "tls-home-with-cipher.conf" );
     ("crowbar fuzzing", `Slow, crowbar_fuzz_config);
   ]

--- a/test/sample-configuration-files/tls-home-with-cipher.conf
+++ b/test/sample-configuration-files/tls-home-with-cipher.conf
@@ -1,0 +1,88 @@
+#
+# Sample OpenVPN configuration file for
+# home using SSL/TLS mode and RSA certificates/keys.
+#
+# '#' or ';' may be used to delimit comments.
+
+# Use a dynamic tun device.
+# For Linux 2.2 or non-Linux OSes,
+# you may want to use an explicit
+# unit number such as "tun1".
+# OpenVPN also supports virtual
+# ethernet "tap" devices.
+dev tun
+
+# Our OpenVPN peer is the office gateway.
+remote 1.2.3.4
+
+# 10.1.0.2 is our local VPN endpoint (home).
+# 10.1.0.1 is our remote VPN endpoint (office).
+ifconfig 10.1.0.2 10.1.0.1
+
+# Our up script will establish routes
+# once the VPN is alive.
+up ./home.up
+
+# In SSL/TLS key exchange, Office will
+# assume server role and Home
+# will assume client role.
+tls-client
+
+# Certificate Authority file
+ca ca.crt
+
+# Our certificate/public key
+cert client.crt
+
+# Our private key
+key client.key
+
+# OpenVPN 2.0 uses UDP port 1194 by default
+# (official port assignment by iana.org 11/04).
+# OpenVPN 1.x uses UDP port 5000 by default.
+# Each OpenVPN tunnel must use
+# a different port number.
+# lport or rport can be used
+# to denote different ports
+# for local and remote.
+; port 1194
+
+# Downgrade UID and GID to
+# "nobody" after initialization
+# for extra security.
+; user nobody
+; group nobody
+
+# If you built OpenVPN with
+# LZO compression, uncomment
+# out the following line.
+; comp-lzo
+
+# Send a UDP ping to remote once
+# every 15 seconds to keep
+# stateful firewall connection
+# alive.  Uncomment this
+# out if you are using a stateful
+# firewall.
+; ping 15
+
+# Uncomment this section for a more reliable detection when a system
+# loses its connection.  For example, dial-ups or laptops that
+# travel to other locations.
+; ping 15
+; ping-restart 45
+; ping-timer-rem
+; persist-tun
+; persist-key
+
+cipher AES-256-CBC
+
+# Verbosity level.
+# 0 -- quiet except for fatal errors.
+# 1 -- mostly quiet, but display non-fatal network errors.
+# 3 -- medium output, good for normal operation.
+# 9 -- verbose, good for troubleshooting
+verb 3
+
+tls-cipher TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384
+tls-ciphersuite TLS_CHACHA20_POLY1305_SHA256


### PR DESCRIPTION
This fixes #45

Also, cipher/ciphersuite and tls-version-min are applied to the TLS configuration (this was missing previously, so tls_version_min had no effect)