### PR TITLE
Config parser: allow dev tun<any string>, as in 'dev tunnel' or 'dev tunmir'

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -662,14 +662,18 @@ let a_dev =
   let a_device_name =
     choice
       [
-        ( string "tun"
-        *> option None
-             (a_number_range 0 128 >>| fun x -> Some ("tun" ^ string_of_int x))
-        >>| fun name -> (Some `Tun, name) );
-        ( string "tap"
-        *> option None
-             (a_number_range 0 128 >>| fun x -> Some ("tap" ^ string_of_int x))
-        >>| fun name -> (Some `Tap, name) );
+        ( string "tun" *> a_line not_control_char >>| fun x ->
+          let name =
+            let x = String.trim x in
+            if x = "" then None else Some ("tun" ^ x)
+          in
+          (Some `Tun, name) );
+        ( string "tap" *> a_line not_control_char >>| fun x ->
+          let name =
+            let x = String.trim x in
+            if x = "" then None else Some ("tap" ^ x)
+          in
+          (Some `Tap, name) );
         (a_single_param >>| fun name -> (None, Some name));
       ]
   in

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -133,6 +133,32 @@ dev tun
     (Ok (minimal_config |> Miragevpn.Config.add Dev (`Tun, None)))
     explicit_dynamic_tun;
 
+  (* issue 43 *)
+  let tun_is_tunnel =
+    (* here [dev-type] is implied *)
+    Fmt.str {|%a
+dev tunnel
+|} Miragevpn.Config.pp minimal_config
+    |> parse_noextern_client
+  in
+  Alcotest.(check (result conf_map pmsg))
+    "explicit dev tunnel implicitly specifying tun"
+    (Ok (minimal_config |> Miragevpn.Config.add Dev (`Tun, Some "tunnel")))
+    tun_is_tunnel;
+
+  (* issue 85 *)
+  let tun_is_tunmir =
+    (* here [dev-type] is implied *)
+    Fmt.str {|%a
+dev tunmir
+|} Miragevpn.Config.pp minimal_config
+    |> parse_noextern_client
+  in
+  Alcotest.(check (result conf_map pmsg))
+    "explicit dev tunmir implicitly specifying tun"
+    (Ok (minimal_config |> Miragevpn.Config.add Dev (`Tun, Some "tunmir")))
+    tun_is_tunmir;
+
   let explicit_tun_str =
     (* this is interesting because it results in multiple
        dev-type stanzas since [dev tun0] implie [dev-type tun] *)


### PR DESCRIPTION
Previously, only tun<numeric> (with numeric in range 0..128) was allowed, which lead to issues. In the end, the dev-type is `Tun if the name starts with 'tun', and `Tap if the name starts with 'tap' -- otherwise the 'dev-type' has to be specified.

Fixes #43 #85