### PR TITLE
packet.decode_header: reverse ack_message_id list

### DIFF
--- a/src/packet.ml
+++ b/src/packet.ml
@@ -84,14 +84,14 @@ let decode_header buf =
     (Cstruct.length buf >= hdr_len + (packet_id_len * arr_len) + rs)
     `Partial
   >>| fun () ->
-  let rec ack_message_id = function
-    | 0 -> []
+  let rec ack_message_id acc = function
+    | 0 -> acc
     | n ->
         let idx = pred n in
         let id = Cstruct.BE.get_uint32 buf (hdr_len + (packet_id_len * idx)) in
-        id :: ack_message_id idx
+        ack_message_id (id :: acc) idx
   in
-  let ack_message_ids = ack_message_id arr_len in
+  let ack_message_ids = ack_message_id [] arr_len in
   let remote_session =
     if arr_len > 0 then
       Some (Cstruct.BE.get_uint64 buf (hdr_len + (packet_id_len * arr_len)))


### PR DESCRIPTION
Previously, the order was not preserved, and since the order is relevant for the hmac computation, the hmac failed.

/cc @reynir