### PR TITLE
Add a little tool to decode tls-crypt-v2 keys

### DIFF
--- a/app/dune
+++ b/app/dune
@@ -34,4 +34,4 @@
  (public_name tls-crypt-v2.tools)
  (package miragevpn)
  (modules tls_crypt_v2)
- (libraries ptime.clock.os ptime hxd.core hxd.string fmt base64 mirage-crypto))
+ (libraries mirage-crypto-rng.unix ptime.clock.os ptime hxd.core hxd.string fmt base64 mirage-crypto))

--- a/app/dune
+++ b/app/dune
@@ -34,4 +34,12 @@
  (public_name tls-crypt-v2.tools)
  (package miragevpn)
  (modules tls_crypt_v2)
- (libraries mirage-crypto-rng.unix ptime.clock.os ptime hxd.core hxd.string fmt base64 mirage-crypto))
+ (libraries
+  mirage-crypto-rng.unix
+  ptime.clock.os
+  ptime
+  hxd.core
+  hxd.string
+  fmt
+  base64
+  mirage-crypto))

--- a/app/dune
+++ b/app/dune
@@ -28,3 +28,10 @@
  (package miragevpn)
  (modules openvpn_config_parser)
  (libraries miragevpn logs logs.fmt fmt.tty))
+
+(executable
+ (name tls_crypt_v2)
+ (public_name tls-crypt-v2.tools)
+ (package miragevpn)
+ (modules tls_crypt_v2)
+ (libraries ptime.clock.os ptime hxd.core hxd.string fmt base64 mirage-crypto))

--- a/app/tls_crypt_v2.ml
+++ b/app/tls_crypt_v2.ml
@@ -1,0 +1,206 @@
+let error_msgf fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
+
+module Tls_crypt_v2_key : sig
+  type t
+
+  val of_cstruct : Cstruct.t -> (t, [> `Msg of string ]) result
+  val to_string : t -> string
+  val cipher_key : t -> Mirage_crypto.Cipher_block.AES.CTR.key
+  val hmac : t -> Cstruct.t
+  val equal : t -> t -> bool
+  val pp_hum : t Fmt.t
+end = struct
+  type t = Cstruct.t (* cipher (64 bytes) + hmac (64 bytes) *)
+
+  let of_cstruct cs =
+    if Cstruct.length cs <> 128
+    then error_msgf "Invalid tls-crypt-v2 key"
+    else
+      let len = Array.fold_left max 0 Mirage_crypto.Cipher_block.AES.CTR.key_sizes in
+      try
+        let secret = Cstruct.sub cs 0 len in
+        let _ = Mirage_crypto.Cipher_block.AES.CTR.of_secret secret in Ok cs
+      with exn -> error_msgf "Invalid AES-CTR secret key: %S" (Printexc.to_string exn)
+
+  let to_string t = Cstruct.to_string t
+
+  let cipher_key cs =
+    let len = Array.fold_left max 0 Mirage_crypto.Cipher_block.AES.CTR.key_sizes in
+    Mirage_crypto.Cipher_block.AES.CTR.of_secret (Cstruct.sub cs 0 len)
+
+  let hmac cs = Cstruct.sub cs 64 64
+  let equal a b = Eqaf_cstruct.equal a b
+
+  let pp_hum ppf cs =
+    let cipher_key = Cstruct.(to_string (sub cs 0 64)) in
+    let hmac = Cstruct.(to_string (sub cs 64 64)) in
+    Fmt.pf ppf "Cipher Key: @[<hov>%a@]\n%!" (Hxd_string.pp Hxd.default) cipher_key;
+    Fmt.pf ppf "HMAC Key:   @[<hov>%a@]\n%!" (Hxd_string.pp Hxd.default) hmac
+end
+
+let _TLS_CRYPT_V2_CLIENT_KEY_LEN = 2048 / 8
+let _TLS_CRYPT_V2_MAX_WKC_LEN = 1024
+let _TLS_CRYPT_V2_TAG_SIZE = 256 / 8
+
+let load_file filename =
+  let ic = open_in filename in
+  let ln = in_channel_length ic in
+  let rs = Bytes.create ln in
+  let finally () = close_in ic in
+  Fun.protect ~finally @@ fun () ->
+    really_input ic rs 0 ln;
+    Bytes.unsafe_to_string rs
+
+module List = struct
+  include List
+
+  let chop lst = match List.rev lst with
+    | [] -> invalid_arg "List.chop"
+    | _ :: lst -> List.rev lst
+
+  let trim lst =
+    List.fold_left (fun acc -> function
+      | "" -> acc
+      | str -> str :: acc) [] lst |> List.rev
+end
+
+module Metadata = struct
+  type t =
+    | User of string
+    | Timestamp of Ptime.t
+
+  let now () =
+    Timestamp (Ptime_clock.now ())
+
+  let to_cstruct = function
+    | User str ->
+        let cs = Cstruct.create (1 + String.length str) in
+        Cstruct.set_uint8 cs 0 0;
+        Cstruct.blit_from_string str 0 cs 1 (String.length str);
+        cs
+    | Timestamp ptime ->
+        let n = Int64.of_float (Ptime.to_float_s ptime) in
+        let cs = Cstruct.create (1 + 8) in
+        Cstruct.set_uint8 cs 0 1;
+        Cstruct.BE.set_uint64 cs 1 n;
+        cs
+
+  let of_cstruct cs =
+    match Cstruct.get_uint8 cs 0 with
+    | 0 ->
+        if Cstruct.length cs > 1
+        then Ok (User Cstruct.(to_string (sub cs 1 (length cs - 1))))
+        else error_msgf "Invalid user metadata"
+    | 1 ->
+        begin
+          try let n = Cstruct.BE.get_uint64 cs 1 in
+              let n = Int64.to_float n in
+              ( match Ptime.of_float_s n with
+              | Some ptime -> Ok (Timestamp ptime)
+              | None -> error_msgf "Invalid timestamp" )
+          with _ -> error_msgf "Invalid timestamp metadata" end
+    | _ -> error_msgf "Invalid metadata"
+    | exception _ -> error_msgf "Invalid metadata"
+
+  let pp_hum ppf = function
+    | User str -> Fmt.pf ppf "User:       %S\n%!" str
+    | Timestamp ptime -> Fmt.pf ppf "Timestamp:  %a\n%!" (Ptime.pp_rfc3339 ()) ptime
+end
+
+let load_pem ~name filename =
+  let ic = open_in filename in
+  let ln = in_channel_length ic in
+  let rs = Bytes.create ln in
+  really_input ic rs 0 ln;
+  let str = load_file filename in
+  match String.split_on_char '\n' str with
+  | [ _ ] -> error_msgf "Invalid %s" name
+  | header :: b64_and_footer when header = "-----BEGIN " ^ name ^ "-----" ->
+    let b64_and_footer = List.trim b64_and_footer in
+    let footer = List.hd (List.rev b64_and_footer) in
+    if footer <> "-----END " ^ name ^ "-----"
+    then error_msgf "Invalid %s" name
+    else
+      let b64 = String.concat "" (List.chop b64_and_footer) in
+      Base64.decode b64
+  | _ -> error_msgf "Invalid %s" name
+
+let load_tls_crypt_v2_server_key filename =
+  let ( let* ) = Result.bind in
+  let* key = load_pem ~name:"OpenVPN tls-crypt-v2 server key" filename in
+  Tls_crypt_v2_key.of_cstruct (Cstruct.of_string key)
+
+let guard ~msg test =
+  if test () then Ok () else Error (`Msg msg)
+
+let tls_crypt_V2_unwrap_client server_key cs =
+  let ( let* ) = Result.bind in
+  let* () = guard ~msg:"Failed to read length" @@ fun () -> Cstruct.length cs >= 2 in
+  let net_len = Cstruct.BE.get_uint16 cs (Cstruct.length cs - 2) in
+  let* () = guard ~msg:"Invalid length" @@ fun () -> net_len = Cstruct.length cs in
+  let* () = guard ~msg:"Failed to read tag" @@ fun () -> Cstruct.length cs >= _TLS_CRYPT_V2_TAG_SIZE in
+  let tag = Cstruct.sub cs 0 _TLS_CRYPT_V2_TAG_SIZE in
+  let module AES_CTR = Mirage_crypto.Cipher_block.AES.CTR in
+  let ctr = AES_CTR.ctr_of_cstruct tag in
+  let* key_and_metadata =
+    try let payload = Cstruct.sub cs _TLS_CRYPT_V2_TAG_SIZE (net_len - _TLS_CRYPT_V2_TAG_SIZE) in
+        Ok (AES_CTR.decrypt ~key:(Tls_crypt_v2_key.cipher_key server_key) ~ctr payload)
+    with _ -> error_msgf "Could not decrypt client key" in
+  let ctx = Mirage_crypto.Hash.SHA256.hmac_empty ~key:(Tls_crypt_v2_key.hmac server_key) in
+  let ctx = Mirage_crypto.Hash.SHA256.hmac_feed ctx (Cstruct.sub cs (Cstruct.length cs - 2) 2) in
+  let ctx = Mirage_crypto.Hash.SHA256.hmac_feed ctx key_and_metadata in
+  let tag' = Mirage_crypto.Hash.SHA256.hmac_get ctx in
+  let* () = guard ~msg:"Client key authentication error" @@ fun () -> Eqaf_cstruct.equal tag tag' = false in
+  let* () = guard ~msg:"Failed to read the client key" @@ fun () -> Cstruct.length key_and_metadata >= (128 * 2) in
+    let* a = Tls_crypt_v2_key.of_cstruct (Cstruct.sub key_and_metadata 0 128) in
+    let* b = Tls_crypt_v2_key.of_cstruct (Cstruct.sub key_and_metadata 128 128) in
+  let metadata = Cstruct.sub key_and_metadata (128 * 2) (Cstruct.length key_and_metadata - (128 * 2)) in
+  let* metadata = Metadata.of_cstruct metadata in
+  Ok (a, b, metadata)
+
+let load_tls_crypt_v2_client_key server_key filename =
+  let ( let* ) = Result.bind in
+  let* str = load_pem ~name:"OpenVPN tls-crypt-v2 client key" filename in
+  let cs = Cstruct.of_string str in
+  let* () = guard ~msg:"Can not read tls-crypt-v2 client key length" @@ fun () ->
+    Cstruct.length cs >= 2 in
+  let net_len = Cstruct.BE.get_uint16 cs (Cstruct.length cs - 2) in
+  let* () = guard ~msg:"Can not locate tls-crypt-v2 wrapped client key" @@ fun () ->
+    Cstruct.length cs >= net_len in
+  let wkc = Cstruct.sub cs (Cstruct.length cs - net_len) net_len in
+  let* () = guard ~msg:"Can not locate tls-crypt-v2 client key" @@ fun () ->
+    Cstruct.length cs - net_len >= (128 * 2) in
+  let kc = Cstruct.sub cs 0 (Cstruct.length cs - net_len) in
+  let* a = Tls_crypt_v2_key.of_cstruct (Cstruct.sub kc 0 128) in
+  let* b = Tls_crypt_v2_key.of_cstruct (Cstruct.sub kc 128 128) in
+  let* (a', b', metadata) = tls_crypt_V2_unwrap_client server_key wkc in
+  let* () = guard ~msg:"Client keys don't correspond" @@ fun () ->
+    Tls_crypt_v2_key.equal a a' in
+  let* () = guard ~msg:"Client keys don't correspond" @@ fun () ->
+    Tls_crypt_v2_key.equal b b' in
+  Ok (a, b, metadata)
+
+let () =
+  match Sys.argv with
+  | [| _; "tls-crypt-v2"; "server"; filename |] when Sys.file_exists filename ->
+    begin match load_tls_crypt_v2_server_key filename with
+    | Ok key -> Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum key
+    | Error (`Msg msg) -> Fmt.epr "%s: %s\n%!" Sys.executable_name msg end
+  | [| _; "tls-crypt-v2"; "client"; filename; server |] when
+    Sys.file_exists filename && Sys.file_exists server ->
+    let result =
+      let ( let* ) = Result.bind in
+      let* server_key = load_tls_crypt_v2_server_key server in
+      let* client_key = load_tls_crypt_v2_client_key server_key filename in
+      Ok (server_key, client_key) in
+    begin match result with
+    | Ok (server_key, (a, b, metadata)) ->
+        Fmt.pr "Server key:\n%!";
+        Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum server_key;
+        Fmt.pr "Client key:\n%!";
+        Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum a;
+        Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum b;
+        Fmt.pr "Metadata:\n%!";
+        Fmt.pr "%a%!" Metadata.pp_hum metadata
+    | Error (`Msg msg) -> Fmt.epr "%s: %s\n%!" Sys.executable_name msg end
+  | _ -> assert false

--- a/app/tls_crypt_v2.ml
+++ b/app/tls_crypt_v2.ml
@@ -28,7 +28,7 @@ end = struct
     let len = Array.fold_left max 0 Mirage_crypto.Cipher_block.AES.CTR.key_sizes in
     Mirage_crypto.Cipher_block.AES.CTR.of_secret (Cstruct.sub cs 0 len)
 
-  let hmac cs = Cstruct.sub cs 64 32
+  let hmac cs = Cstruct.sub cs 64 Mirage_crypto.Hash.SHA256.digest_size
   let equal a b = Eqaf_cstruct.equal a b
 
   let pp_hum ppf cs =

--- a/app/tls_crypt_v2.ml
+++ b/app/tls_crypt_v2.ml
@@ -93,12 +93,15 @@ module Metadata = struct
         else error_msgf "Invalid user metadata"
     | 1 ->
         begin
-          try let n = Cstruct.BE.get_uint64 cs 1 in
+          if Cstruct.length cs <> 1 + 8 then
+            error_msgf "Invalid timestamp: invalid length"
+          else
+            try let n = Cstruct.BE.get_uint64 cs 1 in
               let n = Int64.to_float n in
               ( match Ptime.of_float_s n with
-              | Some ptime -> Ok (Timestamp ptime)
-              | None -> error_msgf "Invalid timestamp" )
-          with _ -> error_msgf "Invalid timestamp metadata" end
+                | Some ptime -> Ok (Timestamp ptime)
+                | None -> error_msgf "Invalid timestamp" )
+            with _ -> error_msgf "Invalid timestamp metadata" end
     | _ -> error_msgf "Invalid metadata"
     | exception _ -> error_msgf "Invalid metadata"
 

--- a/app/tls_crypt_v2.ml
+++ b/app/tls_crypt_v2.ml
@@ -28,7 +28,7 @@ end = struct
     let len = Array.fold_left max 0 Mirage_crypto.Cipher_block.AES.CTR.key_sizes in
     Mirage_crypto.Cipher_block.AES.CTR.of_secret (Cstruct.sub cs 0 len)
 
-  let hmac cs = Cstruct.sub cs 64 64
+  let hmac cs = Cstruct.sub cs 64 32
   let equal a b = Eqaf_cstruct.equal a b
 
   let pp_hum ppf cs =
@@ -150,7 +150,7 @@ let tls_crypt_V2_unwrap_client server_key cs =
   let ctx = Mirage_crypto.Hash.SHA256.hmac_feed ctx (Cstruct.sub cs (Cstruct.length cs - 2) 2) in
   let ctx = Mirage_crypto.Hash.SHA256.hmac_feed ctx key_and_metadata in
   let tag' = Mirage_crypto.Hash.SHA256.hmac_get ctx in
-  let* () = guard ~msg:"Client key authentication error" @@ fun () -> Eqaf_cstruct.equal tag tag' = false in
+  let* () = guard ~msg:"Client key authentication error" @@ fun () -> Eqaf_cstruct.equal tag tag' in
   let* () = guard ~msg:"Failed to read the client key" @@ fun () -> Cstruct.length key_and_metadata >= (128 * 2) in
     let* a = Tls_crypt_v2_key.of_cstruct (Cstruct.sub key_and_metadata 0 128) in
     let* b = Tls_crypt_v2_key.of_cstruct (Cstruct.sub key_and_metadata 128 128) in

--- a/app/tls_crypt_v2.ml
+++ b/app/tls_crypt_v2.ml
@@ -16,20 +16,25 @@ end = struct
   type t = Cstruct.t (* cipher (64 bytes) + hmac (64 bytes) *)
 
   let of_cstruct cs =
-    if Cstruct.length cs <> 128
-    then error_msgf "Invalid tls-crypt-v2 key"
+    if Cstruct.length cs <> 128 then error_msgf "Invalid tls-crypt-v2 key"
     else
-      let len = Array.fold_left max 0 Mirage_crypto.Cipher_block.AES.CTR.key_sizes in
+      let len =
+        Array.fold_left max 0 Mirage_crypto.Cipher_block.AES.CTR.key_sizes
+      in
       try
         let secret = Cstruct.sub cs 0 len in
-        let _ = Mirage_crypto.Cipher_block.AES.CTR.of_secret secret in Ok cs
-      with exn -> error_msgf "Invalid AES-CTR secret key: %S" (Printexc.to_string exn)
+        let _ = Mirage_crypto.Cipher_block.AES.CTR.of_secret secret in
+        Ok cs
+      with exn ->
+        error_msgf "Invalid AES-CTR secret key: %S" (Printexc.to_string exn)
 
   let to_cstruct x = x
   let to_string t = Cstruct.to_string t
 
   let cipher_key cs =
-    let len = Array.fold_left max 0 Mirage_crypto.Cipher_block.AES.CTR.key_sizes in
+    let len =
+      Array.fold_left max 0 Mirage_crypto.Cipher_block.AES.CTR.key_sizes
+    in
     Mirage_crypto.Cipher_block.AES.CTR.of_secret (Cstruct.sub cs 0 len)
 
   let hmac cs = Cstruct.sub cs 64 Mirage_crypto.Hash.SHA256.digest_size
@@ -39,7 +44,9 @@ end = struct
   let pp_hum ppf cs =
     let cipher_key = Cstruct.(to_string (sub cs 0 64)) in
     let hmac = Cstruct.(to_string (sub cs 64 64)) in
-    Fmt.pf ppf "Cipher Key: @[<hov>%a@]\n%!" (Hxd_string.pp Hxd.default) cipher_key;
+    Fmt.pf ppf "Cipher Key: @[<hov>%a@]\n%!"
+      (Hxd_string.pp Hxd.default)
+      cipher_key;
     Fmt.pf ppf "HMAC Key:   @[<hov>%a@]\n%!" (Hxd_string.pp Hxd.default) hmac
 
   let to_base64 cs =
@@ -57,20 +64,20 @@ let load_file filename =
   let rs = Bytes.create ln in
   let finally () = close_in ic in
   Fun.protect ~finally @@ fun () ->
-    really_input ic rs 0 ln;
-    Bytes.unsafe_to_string rs
+  really_input ic rs 0 ln;
+  Bytes.unsafe_to_string rs
 
 module List = struct
   include List
 
-  let chop lst = match List.rev lst with
+  let chop lst =
+    match List.rev lst with
     | [] -> invalid_arg "List.chop"
     | _ :: lst -> List.rev lst
 
   let trim lst =
-    List.fold_left (fun acc -> function
-      | "" -> acc
-      | str -> str :: acc) [] lst |> List.rev
+    List.fold_left (fun acc -> function "" -> acc | str -> str :: acc) [] lst
+    |> List.rev
 end
 
 module String = struct
@@ -82,17 +89,15 @@ module String = struct
       else
         let len' = min n len in
         let str' = String.sub str off len' in
-        go (str' :: acc) str (off + len') (len - len') in
+        go (str' :: acc) str (off + len') (len - len')
+    in
     go [] str 0 (String.length str)
 end
 
 module Metadata = struct
-  type t =
-    | User of string
-    | Timestamp of Ptime.t
+  type t = User of string | Timestamp of Ptime.t
 
-  let now () =
-    Timestamp (Ptime_clock.now ())
+  let now () = Timestamp (Ptime_clock.now ())
 
   let to_cstruct = function
     | User str ->
@@ -110,30 +115,33 @@ module Metadata = struct
   let of_cstruct cs =
     match Cstruct.get_uint8 cs 0 with
     | 0 ->
-        if Cstruct.length cs > 1
-        then Ok (User Cstruct.(to_string (sub cs 1 (length cs - 1))))
+        if Cstruct.length cs > 1 then
+          Ok (User Cstruct.(to_string (sub cs 1 (length cs - 1))))
         else error_msgf "Invalid user metadata"
-    | 1 ->
-        begin
-          if Cstruct.length cs <> 1 + 8 then
-            error_msgf "Invalid timestamp: invalid length"
-          else
-            try let n = Cstruct.BE.get_uint64 cs 1 in
-              let n = Int64.to_float n in
-              ( match Ptime.of_float_s n with
-                | Some ptime -> Ok (Timestamp ptime)
-                | None -> error_msgf "Invalid timestamp" )
-            with _ -> error_msgf "Invalid timestamp metadata" end
+    | 1 -> (
+        if Cstruct.length cs <> 1 + 8 then
+          error_msgf "Invalid timestamp: invalid length"
+        else
+          try
+            let n = Cstruct.BE.get_uint64 cs 1 in
+            let n = Int64.to_float n in
+            match Ptime.of_float_s n with
+            | Some ptime -> Ok (Timestamp ptime)
+            | None -> error_msgf "Invalid timestamp"
+          with _ -> error_msgf "Invalid timestamp metadata")
     | _ -> error_msgf "Invalid metadata"
     | exception _ -> error_msgf "Invalid metadata"
 
   let pp_hum ppf = function
     | User str -> Fmt.pf ppf "User:       %S\n%!" str
-    | Timestamp ptime -> Fmt.pf ppf "Timestamp:  %a\n%!" (Ptime.pp_rfc3339 ()) ptime
+    | Timestamp ptime ->
+        Fmt.pf ppf "Timestamp:  %a\n%!" (Ptime.pp_rfc3339 ()) ptime
 end
 
 type tls_crypt_v2_server_key = Tls_crypt_v2_key.t
-type tls_crypt_v2_client_key = Tls_crypt_v2_key.t * Tls_crypt_v2_key.t * Metadata.t
+
+type tls_crypt_v2_client_key =
+  Tls_crypt_v2_key.t * Tls_crypt_v2_key.t * Metadata.t
 
 let load_pem ~name filename =
   let ic = open_in filename in
@@ -144,13 +152,13 @@ let load_pem ~name filename =
   match String.split_on_char '\n' str with
   | [ _ ] -> error_msgf "Invalid %s" name
   | header :: b64_and_footer when header = "-----BEGIN " ^ name ^ "-----" ->
-    let b64_and_footer = List.trim b64_and_footer in
-    let footer = List.hd (List.rev b64_and_footer) in
-    if footer <> "-----END " ^ name ^ "-----"
-    then error_msgf "Invalid %s" name
-    else
-      let b64 = String.concat "" (List.chop b64_and_footer) in
-      Base64.decode b64
+      let b64_and_footer = List.trim b64_and_footer in
+      let footer = List.hd (List.rev b64_and_footer) in
+      if footer <> "-----END " ^ name ^ "-----" then
+        error_msgf "Invalid %s" name
+      else
+        let b64 = String.concat "" (List.chop b64_and_footer) in
+        Base64.decode b64
   | _ -> error_msgf "Invalid %s" name
 
 let load_tls_crypt_v2_server_key filename =
@@ -174,9 +182,9 @@ let save_tls_crypt_v2_server_key server_key filename =
   close_out oc
 
 let generate_tls_crypt_v2_client_key ?g metadata =
-  let metadata = match metadata with
-    | None -> Metadata.now ()
-    | Some metadata -> metadata in
+  let metadata =
+    match metadata with None -> Metadata.now () | Some metadata -> metadata
+  in
   let a = Tls_crypt_v2_key.generate ?g () in
   let b = Tls_crypt_v2_key.generate ?g () in
   (a, b, metadata)
@@ -186,11 +194,18 @@ let tls_crypt_v2_wrap_client server_key (a, b, metadata) =
   let b = Tls_crypt_v2_key.to_cstruct b in
   let cs = Cstruct.concat [ a; b ] in
   let metadata = Metadata.to_cstruct metadata in
-  let net_len = Cstruct.length cs + Cstruct.length metadata + Mirage_crypto.Hash.SHA256.digest_size + 2 in
+  let net_len =
+    Cstruct.length cs + Cstruct.length metadata
+    + Mirage_crypto.Hash.SHA256.digest_size + 2
+  in
   let net_len =
     let cs = Cstruct.create 2 in
-    Cstruct.BE.set_uint16 cs 0 net_len; cs in
-  let ctx = Mirage_crypto.Hash.SHA256.hmac_empty ~key:(Tls_crypt_v2_key.hmac server_key) in
+    Cstruct.BE.set_uint16 cs 0 net_len;
+    cs
+  in
+  let ctx =
+    Mirage_crypto.Hash.SHA256.hmac_empty ~key:(Tls_crypt_v2_key.hmac server_key)
+  in
   let ctx = Mirage_crypto.Hash.SHA256.hmac_feed ctx net_len in
   let ctx = Mirage_crypto.Hash.SHA256.hmac_feed ctx cs in
   let ctx = Mirage_crypto.Hash.SHA256.hmac_feed ctx metadata in
@@ -198,14 +213,19 @@ let tls_crypt_v2_wrap_client server_key (a, b, metadata) =
   let module AES_CTR = Mirage_crypto.Cipher_block.AES.CTR in
   let ctr = AES_CTR.ctr_of_cstruct tag in
   let wkc =
-    AES_CTR.encrypt ~key:(Tls_crypt_v2_key.cipher_key server_key) ~ctr
-      (Cstruct.concat [ cs; metadata; ]) in
+    AES_CTR.encrypt
+      ~key:(Tls_crypt_v2_key.cipher_key server_key)
+      ~ctr
+      (Cstruct.concat [ cs; metadata ])
+  in
   Cstruct.concat [ tag; wkc; net_len ]
 
 let save_tls_crypt_v2_client_key server_key client_key filename =
   let kc =
-    let (a, b, _) = client_key in
-    Cstruct.concat [ Tls_crypt_v2_key.to_cstruct a; Tls_crypt_v2_key.to_cstruct b ] in
+    let a, b, _ = client_key in
+    Cstruct.concat
+      [ Tls_crypt_v2_key.to_cstruct a; Tls_crypt_v2_key.to_cstruct b ]
+  in
   let wkc = tls_crypt_v2_wrap_client server_key client_key in
   let payload = Cstruct.concat [ kc; wkc ] in
   let payload = Cstruct.to_string payload in
@@ -217,31 +237,59 @@ let save_tls_crypt_v2_client_key server_key client_key filename =
   line oc "-----END OpenVPN tls-crypt-v2 client key-----";
   close_out oc
 
-let guard ~msg test =
-  if test () then Ok () else Error (`Msg msg)
+let guard ~msg test = if test () then Ok () else Error (`Msg msg)
 
 let tls_crypt_V2_unwrap_client server_key cs =
   let ( let* ) = Result.bind in
-  let* () = guard ~msg:"Failed to read length" @@ fun () -> Cstruct.length cs >= 2 in
+  let* () =
+    guard ~msg:"Failed to read length" @@ fun () -> Cstruct.length cs >= 2
+  in
   let net_len = Cstruct.BE.get_uint16 cs (Cstruct.length cs - 2) in
-  let* () = guard ~msg:"Invalid length" @@ fun () -> net_len = Cstruct.length cs in
-  let* () = guard ~msg:"Failed to read tag" @@ fun () -> Cstruct.length cs >= _TLS_CRYPT_V2_TAG_SIZE in
+  let* () =
+    guard ~msg:"Invalid length" @@ fun () -> net_len = Cstruct.length cs
+  in
+  let* () =
+    guard ~msg:"Failed to read tag" @@ fun () ->
+    Cstruct.length cs >= _TLS_CRYPT_V2_TAG_SIZE
+  in
   let tag = Cstruct.sub cs 0 _TLS_CRYPT_V2_TAG_SIZE in
   let module AES_CTR = Mirage_crypto.Cipher_block.AES.CTR in
   let ctr = AES_CTR.ctr_of_cstruct tag in
   let* key_and_metadata =
-    try let payload = Cstruct.sub cs _TLS_CRYPT_V2_TAG_SIZE (net_len - _TLS_CRYPT_V2_TAG_SIZE - 2) in
-        Ok (AES_CTR.decrypt ~key:(Tls_crypt_v2_key.cipher_key server_key) ~ctr payload)
-    with _ -> error_msgf "Could not decrypt client key" in
-  let ctx = Mirage_crypto.Hash.SHA256.hmac_empty ~key:(Tls_crypt_v2_key.hmac server_key) in
-  let ctx = Mirage_crypto.Hash.SHA256.hmac_feed ctx (Cstruct.sub cs (Cstruct.length cs - 2) 2) in
+    try
+      let payload =
+        Cstruct.sub cs _TLS_CRYPT_V2_TAG_SIZE
+          (net_len - _TLS_CRYPT_V2_TAG_SIZE - 2)
+      in
+      Ok
+        (AES_CTR.decrypt
+           ~key:(Tls_crypt_v2_key.cipher_key server_key)
+           ~ctr payload)
+    with _ -> error_msgf "Could not decrypt client key"
+  in
+  let ctx =
+    Mirage_crypto.Hash.SHA256.hmac_empty ~key:(Tls_crypt_v2_key.hmac server_key)
+  in
+  let ctx =
+    Mirage_crypto.Hash.SHA256.hmac_feed ctx
+      (Cstruct.sub cs (Cstruct.length cs - 2) 2)
+  in
   let ctx = Mirage_crypto.Hash.SHA256.hmac_feed ctx key_and_metadata in
   let tag' = Mirage_crypto.Hash.SHA256.hmac_get ctx in
-  let* () = guard ~msg:"Client key authentication error" @@ fun () -> Eqaf_cstruct.equal tag tag' in
-  let* () = guard ~msg:"Failed to read the client key" @@ fun () -> Cstruct.length key_and_metadata >= (128 * 2) in
-    let* a = Tls_crypt_v2_key.of_cstruct (Cstruct.sub key_and_metadata 0 128) in
-    let* b = Tls_crypt_v2_key.of_cstruct (Cstruct.sub key_and_metadata 128 128) in
-  let metadata = Cstruct.sub key_and_metadata (128 * 2) (Cstruct.length key_and_metadata - (128 * 2)) in
+  let* () =
+    guard ~msg:"Client key authentication error" @@ fun () ->
+    Eqaf_cstruct.equal tag tag'
+  in
+  let* () =
+    guard ~msg:"Failed to read the client key" @@ fun () ->
+    Cstruct.length key_and_metadata >= 128 * 2
+  in
+  let* a = Tls_crypt_v2_key.of_cstruct (Cstruct.sub key_and_metadata 0 128) in
+  let* b = Tls_crypt_v2_key.of_cstruct (Cstruct.sub key_and_metadata 128 128) in
+  let metadata =
+    Cstruct.sub key_and_metadata (128 * 2)
+      (Cstruct.length key_and_metadata - (128 * 2))
+  in
   let* metadata = Metadata.of_cstruct metadata in
   Ok (a, b, metadata)
 
@@ -249,61 +297,74 @@ let load_tls_crypt_v2_client_key server_key filename =
   let ( let* ) = Result.bind in
   let* str = load_pem ~name:"OpenVPN tls-crypt-v2 client key" filename in
   let cs = Cstruct.of_string str in
-  let* () = guard ~msg:"Can not read tls-crypt-v2 client key length" @@ fun () ->
-    Cstruct.length cs >= 2 in
+  let* () =
+    guard ~msg:"Can not read tls-crypt-v2 client key length" @@ fun () ->
+    Cstruct.length cs >= 2
+  in
   let net_len = Cstruct.BE.get_uint16 cs (Cstruct.length cs - 2) in
-  let* () = guard ~msg:"Can not locate tls-crypt-v2 wrapped client key" @@ fun () ->
-    Cstruct.length cs >= net_len in
+  let* () =
+    guard ~msg:"Can not locate tls-crypt-v2 wrapped client key" @@ fun () ->
+    Cstruct.length cs >= net_len
+  in
   let wkc = Cstruct.sub cs (Cstruct.length cs - net_len) net_len in
-  let* () = guard ~msg:"Can not locate tls-crypt-v2 client key" @@ fun () ->
-    Cstruct.length cs - net_len >= (128 * 2) in
+  let* () =
+    guard ~msg:"Can not locate tls-crypt-v2 client key" @@ fun () ->
+    Cstruct.length cs - net_len >= 128 * 2
+  in
   let kc = Cstruct.sub cs 0 (Cstruct.length cs - net_len) in
   let* a = Tls_crypt_v2_key.of_cstruct (Cstruct.sub kc 0 128) in
   let* b = Tls_crypt_v2_key.of_cstruct (Cstruct.sub kc 128 128) in
-  let* (a', b', metadata) = tls_crypt_V2_unwrap_client server_key wkc in
-  let* () = guard ~msg:"Client keys don't correspond" @@ fun () ->
-    Tls_crypt_v2_key.equal a a' in
-  let* () = guard ~msg:"Client keys don't correspond" @@ fun () ->
-    Tls_crypt_v2_key.equal b b' in
+  let* a', b', metadata = tls_crypt_V2_unwrap_client server_key wkc in
+  let* () =
+    guard ~msg:"Client keys don't correspond" @@ fun () ->
+    Tls_crypt_v2_key.equal a a'
+  in
+  let* () =
+    guard ~msg:"Client keys don't correspond" @@ fun () ->
+    Tls_crypt_v2_key.equal b b'
+  in
   Ok (a, b, metadata)
 
 let () = Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna)
 
 let () =
   match Sys.argv with
-  | [| _; "tls-crypt-v2"; "server"; filename |] when Sys.file_exists filename ->
-    begin match load_tls_crypt_v2_server_key filename with
-    | Ok key -> Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum key
-    | Error (`Msg msg) -> Fmt.epr "%s: %s\n%!" Sys.executable_name msg end
-  | [| _; "tls-crypt-v2"; "client"; filename; server |] when
-    Sys.file_exists filename && Sys.file_exists server ->
-    let result =
-      let ( let* ) = Result.bind in
-      let* server_key = load_tls_crypt_v2_server_key server in
-      let* client_key = load_tls_crypt_v2_client_key server_key filename in
-      Ok (server_key, client_key) in
-    begin match result with
-    | Ok (server_key, (a, b, metadata)) ->
-        Fmt.pr "Server key:\n%!";
-        Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum server_key;
-        Fmt.pr "Client key:\n%!";
-        Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum a;
-        Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum b;
-        Fmt.pr "Metadata:\n%!";
-        Fmt.pr "%a%!" Metadata.pp_hum metadata
-    | Error (`Msg msg) -> Fmt.epr "%s: %s\n%!" Sys.executable_name msg end
+  | [| _; "tls-crypt-v2"; "server"; filename |] when Sys.file_exists filename
+    -> (
+      match load_tls_crypt_v2_server_key filename with
+      | Ok key -> Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum key
+      | Error (`Msg msg) -> Fmt.epr "%s: %s\n%!" Sys.executable_name msg)
+  | [| _; "tls-crypt-v2"; "client"; filename; server |]
+    when Sys.file_exists filename && Sys.file_exists server -> (
+      let result =
+        let ( let* ) = Result.bind in
+        let* server_key = load_tls_crypt_v2_server_key server in
+        let* client_key = load_tls_crypt_v2_client_key server_key filename in
+        Ok (server_key, client_key)
+      in
+      match result with
+      | Ok (server_key, (a, b, metadata)) ->
+          Fmt.pr "Server key:\n%!";
+          Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum server_key;
+          Fmt.pr "Client key:\n%!";
+          Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum a;
+          Fmt.pr "%a%!" Tls_crypt_v2_key.pp_hum b;
+          Fmt.pr "Metadata:\n%!";
+          Fmt.pr "%a%!" Metadata.pp_hum metadata
+      | Error (`Msg msg) -> Fmt.epr "%s: %s\n%!" Sys.executable_name msg)
   | [| _; "tls-crypt-v2"; "server"; "genkey"; filename |] ->
       let server_key = generate_tls_crypt_v2_server_key () in
       save_tls_crypt_v2_server_key server_key filename
-  | [| _; "tls-crypt-v2"; "client"; "genkey"; filename; server |] when
-    Sys.file_exists server ->
+  | [| _; "tls-crypt-v2"; "client"; "genkey"; filename; server |]
+    when Sys.file_exists server -> (
       let result =
         let ( let* ) = Result.bind in
         let* server_key = load_tls_crypt_v2_server_key server in
         let client_key = generate_tls_crypt_v2_client_key None in
         save_tls_crypt_v2_client_key server_key client_key filename;
-        Ok () in
-      begin match result with
+        Ok ()
+      in
+      match result with
       | Ok () -> ()
-      | Error (`Msg msg) -> Fmt.epr "%s: %s\n%!" Sys.executable_name msg end
+      | Error (`Msg msg) -> Fmt.epr "%s: %s\n%!" Sys.executable_name msg)
   | _ -> assert false

--- a/app/tls_crypt_v2.ml
+++ b/app/tls_crypt_v2.ml
@@ -186,7 +186,7 @@ let tls_crypt_v2_wrap_client server_key (a, b, metadata) =
   let b = Tls_crypt_v2_key.to_cstruct b in
   let cs = Cstruct.concat [ a; b ] in
   let metadata = Metadata.to_cstruct metadata in
-  let net_len = (128 * 2) + (Cstruct.length metadata) + _TLS_CRYPT_V2_TAG_SIZE + 2 in
+  let net_len = Cstruct.length cs + Cstruct.length metadata + Mirage_crypto.Hash.SHA256.digest_size + 2 in
   let net_len =
     let cs = Cstruct.create 2 in
     Cstruct.BE.set_uint16 cs 0 net_len; cs in
@@ -212,7 +212,7 @@ let save_tls_crypt_v2_client_key server_key client_key filename =
   let b64 = Base64.encode_string ~pad:true payload in
   let oc = open_out filename in
   line oc "-----BEGIN OpenVPN tls-crypt-v2 client key-----";
-  let lines = String.split_at 65 b64 in
+  let lines = String.split_at 64 b64 in
   List.iter (line oc) lines;
   line oc "-----END OpenVPN tls-crypt-v2 client key-----";
   close_out oc

--- a/app/tls_crypt_v2.ml
+++ b/app/tls_crypt_v2.ml
@@ -143,7 +143,7 @@ let tls_crypt_V2_unwrap_client server_key cs =
   let module AES_CTR = Mirage_crypto.Cipher_block.AES.CTR in
   let ctr = AES_CTR.ctr_of_cstruct tag in
   let* key_and_metadata =
-    try let payload = Cstruct.sub cs _TLS_CRYPT_V2_TAG_SIZE (net_len - _TLS_CRYPT_V2_TAG_SIZE) in
+    try let payload = Cstruct.sub cs _TLS_CRYPT_V2_TAG_SIZE (net_len - _TLS_CRYPT_V2_TAG_SIZE - 2) in
         Ok (AES_CTR.decrypt ~key:(Tls_crypt_v2_key.cipher_key server_key) ~ctr payload)
     with _ -> error_msgf "Could not decrypt client key" in
   let ctx = Mirage_crypto.Hash.SHA256.hmac_empty ~key:(Tls_crypt_v2_key.hmac server_key) in

--- a/miragevpn.opam
+++ b/miragevpn.opam
@@ -48,6 +48,8 @@ depends: [
   "mtime"
   "dns-client-lwt" {>= "7.0.0"}
   "tuntap" {>= "1.8.1"}
+  "base64" {>= "3.0.0"}
+  "hxd"
   # mirage:
   "dns-client-mirage" {>= "7.0.0"}
   "tcpip" {>= "7.0.0"}

--- a/src/dune
+++ b/src/dune
@@ -16,5 +16,6 @@
   domain-name
   ipaddr
   gmap
-  randomconv)
+  randomconv
+  base64)
  (wrapped true))


### PR DESCRIPTION
This little code show how to decode PEM format keys generated by `openvpn` (see `openvpn --genkey --tls-crypt-v2`). They show metadata and check if the given key is valid. Assume that you have `server.pem` (the server key) and `Alice.pem` (the client key), you can use this little tool with:
```shell-session
$ dune exec app/tls_crypt_v2.exe -- tls-crypt-v2 server server.pem
$ dune exec app/tls_crypt_v2.exe -- tls-crypt-v2 client Alice.pem server.pem
```

The executable requires `hxd` which is probably not installed and required by the OPAM file.