### PR TITLE
Support `auth`

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -123,6 +123,7 @@ module Conf_map = struct
          - Remove it from Ignored Directives and/or Unimplemented Directives
   *)
   type 'a k =
+    | Auth : Mirage_crypto.Hash.hash k
     | Auth_nocache : flag k
     | Auth_retry : [ `Interact | `Nointeract | `None ] k
     | Auth_user_pass : (string * string) k
@@ -240,9 +241,13 @@ module Conf_map = struct
       (fun err -> `Msg ("not a valid config: " ^ err))
       ( ensure_mem Cipher "config must specify 'cipher AES-256-CBC'"
       >>= fun () ->
-        if mem Cipher t && get Cipher t <> "AES-256-CBC" then
-          Error "currently only supported Cipher is 'AES-256-CBC'"
-        else Ok () )
+        (if mem Cipher t && get Cipher t <> "AES-256-CBC" then
+           Error "currently only supported Cipher is 'AES-256-CBC'"
+         else Ok ())
+        >>= fun () ->
+        match find Auth t with
+        | None | Some `SHA1 -> Ok ()
+        | Some _h -> Error "currently only supported auth is 'SHA1'" )
 
   let is_valid_server_config t =
     let ensure_mem k err = if mem k t then Ok () else Error err in
@@ -379,7 +384,18 @@ module Conf_map = struct
         | `TLS_1_1 -> "1.1"
         | `TLS_1_0 -> "1.0")
     in
+    let pp_digest_algorithm ppf h =
+      Fmt.string ppf
+        (match h with
+        | `MD5 -> "MD5"
+        | `SHA1 -> "SHA1"
+        | `SHA224 -> "SHA224"
+        | `SHA256 -> "SHA256"
+        | `SHA384 -> "SHA384"
+        | `SHA512 -> "SHA512")
+    in
     match (k, v) with
+    | Auth, h -> p () "auth %a" pp_digest_algorithm h
     | Auth_nocache, () -> p () "auth-nocache"
     | Auth_retry, `None -> p () "auth-retry none"
     | Auth_retry, `Nointeract -> p () "auth-retry nointeract"
@@ -1292,6 +1308,18 @@ let a_cipher =
   string "cipher" *> a_whitespace *> a_single_param >>| fun v ->
   `Entry (B (Cipher, v))
 
+let a_auth =
+  string "auth" *> a_whitespace *> a_single_param >>= fun h ->
+  (match String.uppercase_ascii h with
+  | "MD5" -> return `MD5
+  | "SHA1" -> return `SHA1
+  | "SHA224" -> return `SHA224
+  | "SHA256" -> return `SHA256
+  | "SHA384" -> return `SHA384
+  | "SHA512" -> return `SHA512
+  | _ -> Fmt.kstr fail "Unknown message digest algorithm %S" h)
+  >>| fun h -> `Entry (B (Auth, h))
+
 let a_replay_window =
   let replay_window a b = `Entry (B (Replay_window, (a, b))) in
   lift2 replay_window
@@ -1481,6 +1509,7 @@ let a_config_entry : line A.t =
          a_link_mtu;
          a_tun_mtu;
          a_cipher;
+         a_auth;
          a_port;
          a_server;
          a_verify_client_cert;

--- a/src/config.ml
+++ b/src/config.ml
@@ -241,9 +241,9 @@ module Conf_map = struct
       (fun err -> `Msg ("not a valid config: " ^ err))
       ( ensure_mem Cipher "config must specify 'cipher AES-256-CBC'"
       >>= fun () ->
-        (if mem Cipher t && get Cipher t <> "AES-256-CBC" then
-           Error "currently only supported Cipher is 'AES-256-CBC'"
-         else Ok ()))
+        if mem Cipher t && get Cipher t <> "AES-256-CBC" then
+          Error "currently only supported Cipher is 'AES-256-CBC'"
+        else Ok () )
 
   let is_valid_server_config t =
     let ensure_mem k err = if mem k t then Ok () else Error err in

--- a/src/config.ml
+++ b/src/config.ml
@@ -243,11 +243,7 @@ module Conf_map = struct
       >>= fun () ->
         (if mem Cipher t && get Cipher t <> "AES-256-CBC" then
            Error "currently only supported Cipher is 'AES-256-CBC'"
-         else Ok ())
-        >>= fun () ->
-        match find Auth t with
-        | None | Some `SHA1 -> Ok ()
-        | Some _h -> Error "currently only supported auth is 'SHA1'" )
+         else Ok ()))
 
   let is_valid_server_config t =
     let ensure_mem k err = if mem k t then Ok () else Error err in

--- a/src/config.ml
+++ b/src/config.ml
@@ -587,6 +587,7 @@ module Defaults = struct
     |> add Renegotiate_seconds 3600
     |> add Handshake_window 60 |> add Transition_window 3600
     |> add Proto (None, `Udp)
+    |> add Auth `SHA1
 
   let client =
     let open Conf_map in

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -105,10 +105,7 @@ let hmacs config =
   match Config.find Tls_auth config with
   | None -> Error (`Msg "no tls auth payload in config")
   | Some (direction, _, hmac1, _, hmac2) ->
-      let hmac_len =
-        Option.value ~default:`SHA1 (Config.find Auth config)
-        |> Mirage_crypto.Hash.digest_size
-      in
+      let hmac_len = Mirage_crypto.Hash.digest_size (Config.get Auth config) in
       let a, b =
         match direction with
         | None -> (hmac1, hmac1)
@@ -122,10 +119,7 @@ let secret config =
   match Config.find Secret config with
   | None -> Error (`Msg "no pre-shared secret found")
   | Some (key1, hmac1, _key2, _hmac2) ->
-      let hmac_len =
-        Option.value ~default:`SHA1 (Config.find Auth config)
-        |> Mirage_crypto.Hash.digest_size
-      in
+      let hmac_len = Mirage_crypto.Hash.digest_size (Config.get Auth config) in
       let hm cs = Cstruct.sub cs 0 hmac_len
       and cipher cs = Cstruct.sub cs 0 32 in
       Ok (cipher key1, hm hmac1, cipher key1, hm hmac1)

--- a/src/miragevpn.mli
+++ b/src/miragevpn.mli
@@ -4,6 +4,7 @@ module Config : sig
   type flag = unit
 
   type 'a k =
+    | Auth : Mirage_crypto.Hash.hash k
     | Auth_nocache : flag k
       (* Erase user-provided credentials ([Askpass] and [Auth_user_pass]) from
          program memory after their user.

--- a/src/packet.ml
+++ b/src/packet.ml
@@ -95,7 +95,9 @@ let decode_header ~hmac_len buf =
   let ack_message_ids = List.init arr_len ack_message_id in
   let remote_session =
     if arr_len > 0 then
-      Some (Cstruct.BE.get_uint64 buf (hdr_len hmac_len + (packet_id_len * arr_len)))
+      Some
+        (Cstruct.BE.get_uint64 buf
+           (hdr_len hmac_len + (packet_id_len * arr_len)))
     else None
   in
   ( {

--- a/src/packet.ml
+++ b/src/packet.ml
@@ -54,9 +54,8 @@ let pp_operation ppf op =
 type packet_id = int32 (* 4 or 8 bytes -- latter in pre-shared key mode *)
 
 let packet_id_len = 4
-let hmac_len = 20 (* SHA1 is what you say *)
 let cipher_block_size = 16
-let hdr_len = 8 + hmac_len + packet_id_len + 4 + 1
+let hdr_len hmac_len = 8 + hmac_len + packet_id_len + 4 + 1
 let guard f e = if f then Ok () else Error e
 
 type header = {
@@ -77,9 +76,9 @@ let pp_header ppf hdr =
     Fmt.(option ~none:(any " ") uint64)
     hdr.remote_session
 
-let decode_header buf =
+let decode_header ~hmac_len buf =
   let open Result.Infix in
-  guard (Cstruct.length buf >= hdr_len) `Partial >>= fun () ->
+  guard (Cstruct.length buf >= hdr_len hmac_len) `Partial >>= fun () ->
   let local_session = Cstruct.BE.get_uint64 buf 0
   and hmac = Cstruct.sub buf 8 hmac_len
   and packet_id = Cstruct.BE.get_uint32 buf (hmac_len + 8)
@@ -87,16 +86,16 @@ let decode_header buf =
   and arr_len = Cstruct.get_uint8 buf (hmac_len + 16) in
   let rs = if arr_len = 0 then 0 else 8 in
   guard
-    (Cstruct.length buf >= hdr_len + (packet_id_len * arr_len) + rs)
+    (Cstruct.length buf >= hdr_len hmac_len + (packet_id_len * arr_len) + rs)
     `Partial
   >>| fun () ->
   let ack_message_id idx =
-    Cstruct.BE.get_uint32 buf (hdr_len + (packet_id_len * idx))
+    Cstruct.BE.get_uint32 buf (hdr_len hmac_len + (packet_id_len * idx))
   in
   let ack_message_ids = List.init arr_len ack_message_id in
   let remote_session =
     if arr_len > 0 then
-      Some (Cstruct.BE.get_uint64 buf (hdr_len + (packet_id_len * arr_len)))
+      Some (Cstruct.BE.get_uint64 buf (hdr_len hmac_len + (packet_id_len * arr_len)))
     else None
   in
   ( {
@@ -107,12 +106,13 @@ let decode_header buf =
       ack_message_ids;
       remote_session;
     },
-    hdr_len + (packet_id_len * arr_len) + rs )
+    hdr_len hmac_len + (packet_id_len * arr_len) + rs )
 
 let encode_header hdr =
   let id_arr_len = packet_id_len * List.length hdr.ack_message_ids in
   let rsid = if id_arr_len = 0 then 0 else 8 in
-  let buf = Cstruct.create (hdr_len + rsid + id_arr_len) in
+  let hmac_len = Cstruct.length hdr.hmac in
+  let buf = Cstruct.create (hdr_len hmac_len + rsid + id_arr_len) in
   Cstruct.BE.set_uint64 buf 0 hdr.local_session;
   Cstruct.blit hdr.hmac 0 buf 8 hmac_len;
   Cstruct.BE.set_uint32 buf (hmac_len + 8) hdr.packet_id;
@@ -126,8 +126,8 @@ let encode_header hdr =
   | None -> ()
   | Some v ->
       assert (rsid <> 0);
-      Cstruct.BE.set_uint64 buf (hdr_len + id_arr_len) v);
-  (buf, hdr_len + rsid + id_arr_len)
+      Cstruct.BE.set_uint64 buf (hdr_len hmac_len + id_arr_len) v);
+  (buf, hdr_len hmac_len + rsid + id_arr_len)
 
 let to_be_signed_header ?(more = 0) op header =
   (* packet_id ++ timestamp ++ operation ++ session_id ++ ack_len ++ acks ++ remote_session ++ msg_id *)
@@ -161,9 +161,9 @@ let pp_control ppf (hdr, id, payload) =
   Fmt.pf ppf "%a message-id %lu@.payload %d bytes" pp_header hdr id
     (Cstruct.length payload)
 
-let decode_control buf =
+let decode_control ~hmac_len buf =
   let open Result.Infix in
-  decode_header buf >>= fun (header, off) ->
+  decode_header ~hmac_len buf >>= fun (header, off) ->
   guard (Cstruct.length buf >= off + 4) `Partial >>| fun () ->
   let message_id = Cstruct.BE.get_uint32 buf off
   and payload = Cstruct.shift buf (off + 4) in
@@ -194,7 +194,7 @@ let decode_protocol proto buf =
       (Cstruct.sub buf 2 plen, Cstruct.shift buf (plen + 2))
   | `Udp -> Ok (buf, Cstruct.empty)
 
-let decode proto buf =
+let decode ~hmac_len proto buf =
   let open Result.Infix in
   decode_protocol proto buf >>= fun (buf', rest) ->
   guard (Cstruct.length buf' >= 1) `Partial >>= fun () ->
@@ -202,9 +202,9 @@ let decode proto buf =
   let op, key = (opkey lsr 3, opkey land 0x07) in
   let payload = Cstruct.shift buf' 1 in
   (int_to_operation op >>= function
-   | Ack -> decode_header payload >>| fun (ack, _) -> `Ack ack
+   | Ack -> decode_header ~hmac_len payload >>| fun (ack, _) -> `Ack ack
    | Data_v1 -> Ok (`Data payload)
-   | op' -> decode_control payload >>| fun ctl -> `Control (op', ctl))
+   | op' -> decode_control ~hmac_len payload >>| fun ctl -> `Control (op', ctl))
   >>| fun res -> (key, res, rest)
 
 let operation = function

--- a/src/state.ml
+++ b/src/state.ml
@@ -208,14 +208,17 @@ let init_session ~my_session_id ?(their_session_id = 0L) ?(compress = false)
 
 let pp_session ppf t =
   Fmt.pf ppf
-    "compression %B protocol %a hmac %s my session %Lu packet %lu@.their session %Lu \
-     packet %lu"
+    "compression %B protocol %a hmac %s my session %Lu packet %lu@.their \
+     session %Lu packet %lu"
     t.compress pp_proto t.protocol
     (match t.hmac_algorithm with
-     | `MD5 -> "MD5" | `SHA1 -> "SHA1" | `SHA224 -> "SHA224"
-     | `SHA256 -> "SHA256" | `SHA384 -> "SHA384" | `SHA512 -> "SHA512")
-    t.my_session_id t.my_packet_id
-    t.their_session_id t.their_packet_id
+    | `MD5 -> "MD5"
+    | `SHA1 -> "SHA1"
+    | `SHA224 -> "SHA224"
+    | `SHA256 -> "SHA256"
+    | `SHA384 -> "SHA384"
+    | `SHA512 -> "SHA512")
+    t.my_session_id t.my_packet_id t.their_session_id t.their_packet_id
 
 type client_state =
   | Resolving of
@@ -288,8 +291,7 @@ let mtu config compress =
     | Some x -> x
   in
   let hmac_len =
-    Option.value ~default:`SHA1
-      (Config.find Auth config)
+    Option.value ~default:`SHA1 (Config.find Auth config)
     |> Mirage_crypto.Hash.digest_size
   in
   (* padding, done on packet_id + [timestamp] + compress + data *)

--- a/src/state.ml
+++ b/src/state.ml
@@ -206,10 +206,10 @@ let init_session ~my_session_id ?(their_session_id = 0L) ?(compress = false)
 
 let pp_session ppf t =
   Fmt.pf ppf
-    "compression %B protocol %a my session %Lu packet %lu@.their \
-     session %Lu packet %lu"
-    t.compress pp_proto t.protocol
-    t.my_session_id t.my_packet_id t.their_session_id t.their_packet_id
+    "compression %B protocol %a my session %Lu packet %lu@.their session %Lu \
+     packet %lu"
+    t.compress pp_proto t.protocol t.my_session_id t.my_packet_id
+    t.their_session_id t.their_packet_id
 
 type client_state =
   | Resolving of

--- a/src/state.ml
+++ b/src/state.ml
@@ -180,7 +180,6 @@ let next_free_ip config is_not_taken =
   isit (Ipaddr.V4.Prefix.first cidr)
 
 type session = {
-  hmac_algorithm : Mirage_crypto.Hash.hash;
   my_session_id : int64;
   my_packet_id : int32; (* this starts from 1l, indicates the next to-be-send *)
   my_hmac : Cstruct.t;
@@ -193,9 +192,8 @@ type session = {
 }
 
 let init_session ~my_session_id ?(their_session_id = 0L) ?(compress = false)
-    ?(protocol = `Tcp) ~hmac_algorithm ~my_hmac ~their_hmac () =
+    ?(protocol = `Tcp) ~my_hmac ~their_hmac () =
   {
-    hmac_algorithm;
     my_session_id;
     my_packet_id = 1l;
     my_hmac;
@@ -208,16 +206,9 @@ let init_session ~my_session_id ?(their_session_id = 0L) ?(compress = false)
 
 let pp_session ppf t =
   Fmt.pf ppf
-    "compression %B protocol %a hmac %s my session %Lu packet %lu@.their \
+    "compression %B protocol %a my session %Lu packet %lu@.their \
      session %Lu packet %lu"
     t.compress pp_proto t.protocol
-    (match t.hmac_algorithm with
-    | `MD5 -> "MD5"
-    | `SHA1 -> "SHA1"
-    | `SHA224 -> "SHA224"
-    | `SHA256 -> "SHA256"
-    | `SHA384 -> "SHA384"
-    | `SHA512 -> "SHA512")
     t.my_session_id t.my_packet_id t.their_session_id t.their_packet_id
 
 type client_state =

--- a/src/state.ml
+++ b/src/state.ml
@@ -193,7 +193,7 @@ type session = {
 }
 
 let init_session ~my_session_id ?(their_session_id = 0L) ?(compress = false)
-    ?(protocol = `Tcp) ?(hmac_algorithm = `SHA1) ~my_hmac ~their_hmac () =
+    ?(protocol = `Tcp) ~hmac_algorithm ~my_hmac ~their_hmac () =
   {
     hmac_algorithm;
     my_session_id;


### PR DESCRIPTION
A (nice-ish) parse error is raised if the hash is not one of those in mirage-crypto. Furthermore, `is_valid_config` checks that only `auth sha1` may be present for now.