### PR TITLE
run tests and crowbar tests in separate binaries

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -1463,11 +1463,12 @@ let a_not_implemented =
       string "log";
       (* TODO: *)
       string "redirect-gateway";
+      string "block-outside-dns";
+      string "remote-cert-eku";
       string "up";
       string "dh";
       string "explicit-exit-notify";
     ]
-  <* a_whitespace
   >>= fun key ->
   a_line not_control_char >>| fun rest ->
   Log.warn (fun m -> m "IGNORING %S %S" key rest);

--- a/test/crowbar_tests.ml
+++ b/test/crowbar_tests.ml
@@ -1,0 +1,27 @@
+let error_msgf fmt = Fmt.kstr (fun msg -> Error (`Msg msg)) fmt
+
+let parse_noextern_client conf =
+  Miragevpn.Config.parse_client
+    ~string_of_file:(fun path ->
+      error_msgf
+        "this test suite does not read external files, but a config asked for: \
+         %S"
+        path)
+    conf
+
+let crowbar_fuzz_config () =
+  Crowbar.add_test ~name:"Fuzzing doesn't crash Config.parse_client"
+    [ Crowbar.bytes ] (fun s ->
+      try
+        Crowbar.check
+          (ignore @@ parse_noextern_client s;
+           true)
+      with _ -> Crowbar.bad_test ())
+
+let tests = [ ("crowbar fuzzing", `Slow, crowbar_fuzz_config) ]
+let tests = [ ("Crowbar tests", tests) ]
+
+let () =
+  Logs.set_reporter @@ Logs_fmt.reporter ~dst:Format.std_formatter ();
+  Logs.(set_level @@ Some Debug);
+  Alcotest.run "Crowbar tests" tests

--- a/test/dune
+++ b/test/dune
@@ -1,9 +1,14 @@
 (test
- (name test_engine)
- (modules test_engine config_tests)
- (libraries alcotest crowbar fmt logs.fmt miragevpn)
+ (name config_tests)
+ (modules config_tests)
+ (libraries alcotest fmt logs.fmt miragevpn)
  (deps
   (source_tree sample-configuration-files)))
+
+(test
+ (name crowbar_tests)
+ (modules crowbar_tests)
+ (libraries alcotest logs.fmt miragevpn crowbar))
 
 ;(executable
 ;  (public_name config_afl)

--- a/test/sample-configuration-files/windows-riseup-client.conf
+++ b/test/sample-configuration-files/windows-riseup-client.conf
@@ -31,7 +31,7 @@ remote 198.252.153.226 443
 # other possibilities, if the above does not work:
 #remote 198.252.153.226 80
 #remote 198.252.153.226 1194
-auth-user-pass
+auth-user-pass auth
 
 redirect-gateway
 verb 4

--- a/test/test_engine.ml
+++ b/test/test_engine.ml
@@ -1,6 +1,0 @@
-let tests = [ ("Config_tests", Config_tests.tests) ]
-
-let () =
-  Logs.set_reporter @@ Logs_fmt.reporter ~dst:Format.std_formatter ();
-  Logs.(set_level @@ Some Debug);
-  Alcotest.run "MirageVPN tests" tests


### PR DESCRIPTION
previously, there was a single test binary which exit code was always 0 (thus test failures weren't detected in CI)

- fix tests: default configuration now has auth SHA1
- enable wild-client and windows-riseup-client configurations
- for the latter, ignore block-outside-dns and remote-cert-eku