### PR TITLE
Tls-crypt-v2 (rewrite)

### DIFF
--- a/src/result.ml
+++ b/src/result.ml
@@ -7,3 +7,8 @@ module Infix = struct
   let ( >>= ) = bind
   let ( >>| ) x f = map f x
 end
+
+module Syntax = struct
+  let ( let* ) = bind
+  let ( let+ ) x f = map f x
+end


### PR DESCRIPTION
This is an alternative to #105. Tls-crypt-v2 requires some restructuring of code. The packet encoding is different enough that it warrants its own separate implementation. Packet decoding is even further removed and is to be done in two stages.