### PR TITLE
rename "own_" to "my_" and "peer_" to "their_", following the codebase

### DIFF
--- a/src/engine.ml
+++ b/src/engine.ml
@@ -290,30 +290,28 @@ let prf ?sids ~label ~secret ~client_random ~server_random len =
 
 let derive_keys session (my_key_material : State.my_key_material)
     (their_key_material : Packet.tls_data) =
-  let ( server,
-        ( pre_master,
-          client_random,
-          server_random,
-          client_random',
-          server_random',
-          sids ) ) =
-    if Cstruct.(equal empty my_key_material.pre_master) then
-      (* we're the server *)
-      ( true,
-        ( their_key_material.pre_master,
-          their_key_material.random1,
-          my_key_material.random1,
-          their_key_material.random2,
-          my_key_material.random2,
-          (session.their_session_id, session.my_session_id) ) )
+  (* are we the server? *)
+  let server = Cstruct.is_empty my_key_material.pre_master in
+  let ( pre_master,
+        client_random,
+        server_random,
+        client_random',
+        server_random',
+        sids ) =
+    if server then
+      ( their_key_material.pre_master,
+        their_key_material.random1,
+        my_key_material.random1,
+        their_key_material.random2,
+        my_key_material.random2,
+        (session.their_session_id, session.my_session_id) )
     else
-      ( false,
-        ( my_key_material.pre_master,
-          my_key_material.random1,
-          their_key_material.random1,
-          my_key_material.random2,
-          their_key_material.random2,
-          (session.my_session_id, session.their_session_id) ) )
+      ( my_key_material.pre_master,
+        my_key_material.random1,
+        their_key_material.random1,
+        my_key_material.random2,
+        their_key_material.random2,
+        (session.my_session_id, session.their_session_id) )
   in
   let master_key =
     prf ~label:"OpenVPN master secret" ~secret:pre_master ~client_random

--- a/src/state.ml
+++ b/src/state.ml
@@ -1,4 +1,4 @@
-type own_key_material = {
+type my_key_material = {
   pre_master : Cstruct.t; (* only in client -> server, 48 bytes *)
   random1 : Cstruct.t; (* 32 bytes *)
   random2 : Cstruct.t; (* 32 bytes *)
@@ -65,8 +65,8 @@ let pp_keys ppf t =
 type channel_state =
   | Expect_reset
   | TLS_handshake of Tls.Engine.state
-  | TLS_established of Tls.Engine.state * own_key_material
-  | Push_request_sent of Tls.Engine.state * own_key_material * Packet.tls_data
+  | TLS_established of Tls.Engine.state * my_key_material
+  | Push_request_sent of Tls.Engine.state * my_key_material * Packet.tls_data
   | Established of keys
 
 let pp_channel_state ppf = function


### PR DESCRIPTION
(their_session_id, their_packet_id, etc.)