### PR TITLE
Only send IV_NCP=2 when supporting AES GCM ciphers

### DIFF
--- a/src/engine.ml
+++ b/src/engine.ml
@@ -352,12 +352,16 @@ let maybe_kex_client rng config tls =
     let pull = Config.mem Pull config in
     let user_pass = Config.find Auth_user_pass config in
     let peer_info =
-      let ciphers =
-        String.concat ":"
-          (List.map Config.aead_cipher_to_string
-             (Config.get Data_ciphers config))
+      let ciphers = Config.get Data_ciphers config in
+      let maybe_iv_ncp_2 =
+        if List.mem `AES_128_GCM ciphers && List.mem `AES_256_GCM ciphers then
+          [ "IV_NCP=2" ]
+        else []
       in
-      Some [ "IV_PLAT=mirage"; "IV_CIPHERS=" ^ ciphers; "IV_NCP=2" ]
+      let ciphers =
+        String.concat ":" (List.map Config.aead_cipher_to_string ciphers)
+      in
+      Some (maybe_iv_ncp_2 @ [ "IV_PLAT=mirage"; "IV_CIPHERS=" ^ ciphers ])
     in
     let peer_info =
       match peer_info with


### PR DESCRIPTION
A quirk from OpenVPN 2.4 is that the peer-info value IV_NCP=2 signals the client supports (and wants to use) AES-128-GCM and AES-256-GCM. Newer openvpn servers (>= 2.5) will look after IV_NCP=2 if IV_CIPHERS is not present.

The IV_NCP=2 value could be removed if we do not desire to support OpenVPN 2.4 (and other implementations with the same quirk).

Addresses #152.