### PR TITLE
Refactor init_channel, rekey for tls-crypt-v2

### DIFF
--- a/src/engine.ml
+++ b/src/engine.ml
@@ -93,14 +93,14 @@ let compute_hmac key p hmac_algorithm hmac_key =
   Mirage_crypto.Hash.mac hmac_algorithm ~key:hmac_key tbs
 
 let hmac_and_out protocol { hmac_algorithm; my_hmac; _ }
-    ((key, p) : [< Packet.pkt_ack | Packet.pkt_control ] Packet.t) =
+    (key, (p : [< Packet.ack | Packet.control ])) =
   let hmac = compute_hmac key p hmac_algorithm my_hmac in
   let header = Packet.header p in
   let p' = Packet.with_header { header with Packet.hmac } p in
   Packet.encode protocol (key, p')
 
 let encrypt_and_out protocol { my_key; my_hmac; _ }
-    ((key, p) : [< Packet.pkt_ack | Packet.pkt_control ] Packet.t) =
+    (key, (p : [< Packet.ack | Packet.control ])) =
   let to_be_signed = Packet.Tls_crypt.to_be_signed key p in
   let hmac = Mirage_crypto.Hash.SHA256.hmac ~key:my_hmac to_be_signed in
   let iv = Cstruct.sub hmac 0 16 in
@@ -900,7 +900,7 @@ type error =
   | `Mismatch_my_session_id of transport * Packet.header
   | `Msg_id_required_in_fresh_key of transport * int * Packet.header
   | `Different_message_id_expected_fresh_key of transport * int * Packet.header
-  | `Bad_mac of t * Cstruct.t * Packet.pkt Packet.t
+  | `Bad_mac of t * Cstruct.t * Packet.t
   | `No_transition of channel * Packet.operation * Cstruct.t
   | `Tls of
     [ `Alert of Tls.Packet.alert_type | `Eof | `Fail of Tls.Engine.failure ]

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -76,7 +76,6 @@ let header session transport timestamp =
     {
       Packet.local_session = session.my_session_id;
       hmac = Cstruct.empty;
-      (* placeholder *)
       packet_id;
       timestamp;
       ack_message_ids;

--- a/src/state.ml
+++ b/src/state.ml
@@ -12,7 +12,7 @@ type transport = {
   their_message_id : int32;
       (* the first should be 0l, indicates the next to-be-received *)
   last_acked_message_id : int32;
-  out_packets : (int64 * Packet.pkt_control Packet.t) IM.t;
+  out_packets : (int64 * (int * Packet.control)) IM.t;
 }
 
 let pp_transport ppf t =

--- a/src/state.ml
+++ b/src/state.ml
@@ -12,7 +12,7 @@ type transport = {
   their_message_id : int32;
       (* the first should be 0l, indicates the next to-be-received *)
   last_acked_message_id : int32;
-  out_packets : (int64 * Cstruct.t) IM.t;
+  out_packets : (int64 * Packet.t) IM.t;
 }
 
 let pp_transport ppf t =

--- a/src/state.ml
+++ b/src/state.ml
@@ -12,7 +12,7 @@ type transport = {
   their_message_id : int32;
       (* the first should be 0l, indicates the next to-be-received *)
   last_acked_message_id : int32;
-  out_packets : (int64 * Packet.t) IM.t;
+  out_packets : (int64 * Packet.pkt_control Packet.t) IM.t;
 }
 
 let pp_transport ppf t =


### PR DESCRIPTION
- Refactor init_channel and remove init_channel_tls_crypt
- Use Cstruct.empty as hmac placeholder
- Pass Packet.t over a separate keyid and Packet.pkt
- Implement tls-crypt-v2 rekeying
- Store Packet.t in out_packets rather than serialized Cstruct.t. This can allow for retransmission with new replay packet id.