### PR TITLE
Hmac cookie support

### DIFF
--- a/src/engine.ml
+++ b/src/engine.ml
@@ -575,7 +575,9 @@ let incoming_control_client config rng session channel now op data =
   match (channel.channel_st, op) with
   | Expect_reset, (Packet.Hard_reset_server_v2 | Packet.Soft_reset_v2) ->
       (* for rekey we receive a soft_reset -- a bit alien that we don't send soft_reset *)
-      (* we reply with ACK + TLS client hello! *)
+      (* we reply with embedded ACK + TLS client hello! *)
+      (* NOTE: For tls-crypt-v2 hmac cookies it is important we don't send a
+         dedicated ACK as we need to ensure the Control_wkc arrives first *)
       let tls, ch =
         let authenticator =
           match Config.find Ca config with
@@ -1852,6 +1854,7 @@ let incoming ?(is_not_taken = fun _ip -> false) state buf =
                                 act )
                           | _ -> assert false))))
         in
+        (* Invariant: [linger] is always empty for UDP *)
         if Cstruct.is_empty linger then Ok (state, out, act)
         else multi linger (state, out, act)
   in

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1364,7 +1364,7 @@ let wrap_hmac_control now ts mtu session tls_auth key transport outs =
   in
   (session, transport, List.rev outs)
 
-let wrap_tls_crypt_control now ts mtu session (tls_crypt, wkc) hmac_cookie key
+let wrap_tls_crypt_control now ts mtu session (tls_crypt, wkc) needs_wkc key
     transport outs =
   let now_ts = ptime_to_ts_exn now in
   let acks = bytes_of_acks transport in
@@ -1372,7 +1372,7 @@ let wrap_tls_crypt_control now ts mtu session (tls_crypt, wkc) hmac_cookie key
      packet, the Control_wkc has room for the /cleartext/ wkc, and fix the
      packet length afterwards *)
   let session, transport, maybe_out, outs =
-    match (hmac_cookie, outs) with
+    match (needs_wkc, outs) with
     | true, (`Control, data) :: rest ->
         let l = min (mtu - Cstruct.length wkc) (Cstruct.length data) in
         let data, data' = Cstruct.split data l in
@@ -1746,7 +1746,7 @@ let incoming ?(is_not_taken = fun _ip -> false) state buf =
                     Packet.Tls_crypt.decode_decrypted_control cleartext
                       decrypted
                   in
-                  let* hmac_cookie_supported =
+                  let* needs_wkc =
                     match op with
                     | Hard_reset_server_v2 ->
                         Packet.decode_early_negotiation_tlvs data
@@ -1804,8 +1804,8 @@ let incoming ?(is_not_taken = fun _ip -> false) state buf =
                       in
                       let session, transport, encs =
                         wrap_tls_crypt_control (state.now ()) (state.ts ())
-                          my_mtu state.session (tls_crypt, wkc)
-                          hmac_cookie_supported key ch.transport out'
+                          my_mtu state.session (tls_crypt, wkc) needs_wkc key
+                          ch.transport out'
                       in
                       let out = out @ encs
                       and ch = { ch with transport }

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1511,6 +1511,7 @@ let incoming ?(is_not_taken = fun _ip -> false) state buf =
         (* we don't need to check protocol as [`Tcp_partial] is only ever returned for tcp *)
         Ok ({ state with linger = buf }, out, act)
     | Ok (op, key, payload, linger) ->
+        let state = { state with linger } in
         let* state, out, act =
           match find_channel state key op with
           | None ->

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1364,9 +1364,42 @@ let wrap_hmac_control now ts mtu session tls_auth key transport outs =
   in
   (session, transport, List.rev outs)
 
-let wrap_tls_crypt_control now ts mtu session tls_crypt key transport outs =
+let wrap_tls_crypt_control now ts mtu session (tls_crypt, wkc) hmac_cookie key
+    transport outs =
   let now_ts = ptime_to_ts_exn now in
   let acks = bytes_of_acks transport in
+  (* If we reply with hmac cookie we must split such that the first control
+     packet, the Control_wkc has room for the /cleartext/ wkc, and fix the
+     packet length afterwards *)
+  let session, transport, maybe_out, outs =
+    match (hmac_cookie, outs) with
+    | true, (`Control, data) :: rest ->
+        let l = min (mtu - Cstruct.length wkc) (Cstruct.length data) in
+        let data, data' = Cstruct.split data l in
+        let rest =
+          if Cstruct.is_empty data' then rest else (`Control, data') :: rest
+        in
+        let session, transport, header = header session transport now_ts in
+        let transport, sn = next_sequence_number transport in
+        let p = `Control (Packet.Control_wkc, (header, sn, data)) in
+        (* First we encrypt *)
+        let out = encrypt_and_out session.protocol tls_crypt (key, p) in
+        (* Then we append wkc and fix the length if TCP *)
+        let len =
+          Cstruct.length out
+          - match session.protocol with `Tcp -> 2 | `Udp -> 0
+        in
+        let out = Cstruct.append out wkc in
+        let proto = Packet.encode_protocol session.protocol len in
+        Cstruct.blit proto 0 out 0 (Cstruct.length proto);
+        (session, transport, Some out, rest)
+    | true, _ ->
+        Log.warn (fun m ->
+            m "wrap_tls_crypt_control: expected control to append wkc");
+        (session, transport, None, outs)
+    | false, _ -> (session, transport, None, outs)
+  in
+  (* we split the remainder control packets *)
   let outs = split_control ~acks mtu outs in
   let session, transport, outs =
     List.fold_left
@@ -1397,7 +1430,11 @@ let wrap_tls_crypt_control now ts mtu session tls_crypt key transport outs =
         (session, { transport with out_packets }, out :: acc))
       (session, transport, []) outs
   in
-  (session, transport, List.rev outs)
+  let outs =
+    let outs = List.rev outs in
+    Option.fold ~none:outs ~some:(fun c_wkc -> c_wkc :: outs) maybe_out
+  in
+  (session, transport, outs)
 
 let merge_payload a b =
   match (a, b) with
@@ -1456,7 +1493,7 @@ let find_channel state key op =
           | Server_tls_auth _ ),
           Packet.(
             ( Control | Ack | Data_v1 | Hard_reset_client_v2
-            | Hard_reset_server_v2 | Hard_reset_client_v3 )) ) ->
+            | Hard_reset_server_v2 | Hard_reset_client_v3 | Control_wkc )) ) ->
           Log.warn (fun m ->
               m "ignoring unexpected packet %a in %a" Packet.pp_operation op pp
                 state);
@@ -1693,7 +1730,7 @@ let incoming ?(is_not_taken = fun _ip -> false) state buf =
                       Ok (set_ch state ch, out, act))
               | Packet.Hard_reset_client_v3, Client_tls_crypt _ ->
                   Error (`No_transition (ch, op, payload))
-              | _control_op, Client_tls_crypt { tls_crypt = tls_crypt, _wkc; _ }
+              | _control_op, Client_tls_crypt { tls_crypt = tls_crypt, wkc; _ }
                 -> (
                   let* cleartext, off =
                     Packet.Tls_crypt.decode_cleartext_header payload
@@ -1708,6 +1745,12 @@ let incoming ?(is_not_taken = fun _ip -> false) state buf =
                   let* ((_, _, data) as control) =
                     Packet.Tls_crypt.decode_decrypted_control cleartext
                       decrypted
+                  in
+                  let* hmac_cookie_supported =
+                    match op with
+                    | Hard_reset_server_v2 ->
+                        Packet.decode_early_negotiation_tlvs data
+                    | _ -> Ok false
                   in
                   let p = `Control (op, control) in
                   let to_be_signed = Packet.Tls_crypt.to_be_signed key p in
@@ -1727,10 +1770,7 @@ let incoming ?(is_not_taken = fun _ip -> false) state buf =
                     | Expect_reset, Hard_reset_server_v2 ->
                         let hdr = Packet.header p in
                         Log.warn (fun m ->
-                            m "Hard_reset_client_v2 data: %a" Cstruct.hexdump_pp
-                              data);
-                        Log.warn (fun m ->
-                            m "fixing their_replay_id: %lx" hdr.replay_id);
+                            m "fixing their_replay_id: %08lx" hdr.replay_id);
                         { state.session with their_replay_id = hdr.replay_id }
                     | _ -> state.session
                   in
@@ -1764,7 +1804,8 @@ let incoming ?(is_not_taken = fun _ip -> false) state buf =
                       in
                       let session, transport, encs =
                         wrap_tls_crypt_control (state.now ()) (state.ts ())
-                          my_mtu state.session tls_crypt key ch.transport out'
+                          my_mtu state.session (tls_crypt, wkc)
+                          hmac_cookie_supported key ch.transport out'
                       in
                       let out = out @ encs
                       and ch = { ch with transport }
@@ -1811,7 +1852,8 @@ let incoming ?(is_not_taken = fun _ip -> false) state buf =
                                 act )
                           | _ -> assert false))))
         in
-        multi linger (state, out, act)
+        if Cstruct.is_empty linger then Ok (state, out, act)
+        else multi linger (state, out, act)
   in
   let+ s', out, act =
     multi (Cstruct.append state.linger buf) (state, [], None)
@@ -1996,6 +2038,7 @@ let handle_client_tls_crypt t s tls_crypt wkc ev =
           let my_session_id = Randomconv.int64 t.rng in
           let protocol = match remote idx with _, _, proto -> proto in
           let session = init_session ~my_session_id ~protocol () in
+          let session = { session with my_replay_id = 0x0f000001l } in
           let session, channel, out =
             init_channel ~payload:wkc Packet.Hard_reset_client_v3 session 0 now
               ts

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1396,9 +1396,9 @@ let wrap_tls_crypt_control now ts mtu session (tls_crypt, wkc) needs_wkc key
         Cstruct.blit proto 0 out 0 (Cstruct.length proto);
         (session, transport, Some out, rest)
     | true, _ ->
-        Log.warn (fun m ->
+        Log.err (fun m ->
             m "wrap_tls_crypt_control: expected control to append wkc");
-        (session, transport, None, outs)
+        assert false
     | false, _ -> (session, transport, None, outs)
   in
   (* we split the remainder control packets *)

--- a/src/packet.ml
+++ b/src/packet.ml
@@ -25,6 +25,7 @@ type operation =
   | Hard_reset_client_v2
   | Hard_reset_server_v2
   | Hard_reset_client_v3
+  | Control_wkc
 
 let operation_to_int, int_to_operation =
   let ops =
@@ -36,6 +37,7 @@ let operation_to_int, int_to_operation =
       (Hard_reset_client_v2, 7);
       (Hard_reset_server_v2, 8);
       (Hard_reset_client_v3, 10);
+      (Control_wkc, 11);
     ]
   in
   let rev_ops = List.map (fun (a, b) -> (b, a)) ops in
@@ -54,7 +56,8 @@ let pp_operation ppf op =
     | Data_v1 -> "data v1"
     | Hard_reset_client_v2 -> "hard reset client v2"
     | Hard_reset_server_v2 -> "hard reset server v2"
-    | Hard_reset_client_v3 -> "hard reset client v3")
+    | Hard_reset_client_v3 -> "hard reset client v3"
+    | Control_wkc -> "control wkc")
 
 let id_len = 4
 let session_id_len = 8
@@ -607,11 +610,11 @@ module Iv_proto = struct
   let byte xs = List.fold_left (fun b x -> b lor (1 lsl bit x)) 0 xs
 end
 
+(* We only support one flag, so we return [bool] *)
 let decode_early_negotiation_tlvs data =
   let open Result.Syntax in
   let rec go acc data =
-    if Cstruct.is_empty data then
-      Ok acc
+    if Cstruct.is_empty data then Ok acc
     else
       let* () = guard (Cstruct.length data >= 4) `Partial in
       let typ = Cstruct.BE.get_uint16 data 0
@@ -621,8 +624,7 @@ let decode_early_negotiation_tlvs data =
         let* () = guard (len = 2) (`Malformed "Bad EARLY_NEG_FLAGS") in
         let flags = Cstruct.BE.get_uint16 data 4 in
         go (acc || flags = 0x0001 (* RESEND_WKC *)) (Cstruct.shift data 6)
-      else
-        (* skip *)
+      else (* skip *)
         go acc (Cstruct.shift data (4 + len))
   in
   go false data

--- a/src/packet.ml
+++ b/src/packet.ml
@@ -606,3 +606,23 @@ module Iv_proto = struct
   let bit = function Request_push -> 2 | Tls_key_export -> 3
   let byte xs = List.fold_left (fun b x -> b lor (1 lsl bit x)) 0 xs
 end
+
+let decode_early_negotiation_tlvs data =
+  let open Result.Syntax in
+  let rec go acc data =
+    if Cstruct.is_empty data then
+      Ok acc
+    else
+      let* () = guard (Cstruct.length data >= 4) `Partial in
+      let typ = Cstruct.BE.get_uint16 data 0
+      and len = Cstruct.BE.get_uint16 data 2 in
+      let* () = guard (Cstruct.length data >= 4 + len) `Partial in
+      if typ = 0x0001 (* EARLY_NEG_FLAGS *) then
+        let* () = guard (len = 2) (`Malformed "Bad EARLY_NEG_FLAGS") in
+        let flags = Cstruct.BE.get_uint16 data 4 in
+        go (acc || flags = 0x0001 (* RESEND_WKC *)) (Cstruct.shift data 6)
+      else
+        (* skip *)
+        go acc (Cstruct.shift data (4 + len))
+  in
+  go false data


### PR DESCRIPTION
This adds support for hmac cookies in tls-crypt-v2 for the client. The client signals support and parses flags (encoded using TLV) in the server's response. The client then sends instead of a `Control` packet a `Control_wkc` packet that is essentially the same just with another op code and with `wKc` appended in cleartext.

What I found interesting is that the server responds with (replay) packet id of `0x0f000001` if *we* don't use that (replay) packet id. Presumably to signal support for hmac cookies even if the client didn't ask. This comment says a *peer* can use that packet id value suggesting the server is allowed to use this way as well:
https://github.com/OpenVPN/openvpn/blob/f53f06316dbb804128fc5cbee1d8edb274ce81df/src/openvpn/ssl_pkt.h#L302-L308

I have not tested if this is actually the case.

Another observation I had was that the OpenVPN implementation does *not* send `CONTROL_WKC_V1` when using TCP. Presumably this is because a handshake has already been performed in the TCP layer, and hmac cookies are less important for TCP. This implementation does *not* do anything differently for TCP or UDP.

I need to test this works with TCP as well.

I also fix UDP which I broke in an earlier PR.

Fixes #151.