### PR TITLE
add bsd 2 clause license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,23 @@
+Copyright (c) 2019 robur.coop
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or
+  other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/miragevpn.opam
+++ b/miragevpn.opam
@@ -7,7 +7,7 @@ bug-reports:  "https://github.com/robur-coop/miragevpn/issues"
 doc:          "https://github.com/robur-coop/miragevpn/doc"
 author:       ["robur"]
 maintainer:   ["robur"]
-license:      "AGPL"
+license:      "BSD-2-Clause"
 
 build: [
   ["dune" "subst" ] {dev}


### PR DESCRIPTION
The reasoning behind it is: we're all fine with that license, and we enjoy writing that code so much that it's fine for anyone to use, extend, do whatever they want with it. While we're also fine with AGPL, this may prevent people from using this software (namely in companies whose legal departments are allergic to GPL/AGPL [due to unresolved issues of these licenses]).

Please @cfcs could you approve (or disapprove) this license change, since you contributed quite a lot back than.

Thanks a lot.