### PR TITLE
Delay parsing of inline blocks

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version = 0.26.0
+version = 0.26.1

--- a/src/config.ml
+++ b/src/config.ml
@@ -637,6 +637,7 @@ end
 open Conf_map
 
 type block = [ `Inline of string * string ]
+
 type non_block =
   [ `Entries of b list
   | `Entry of b
@@ -1857,8 +1858,8 @@ let parse_next (effect : parser_effect) initial_state :
     let* thing = parse_inline payload kind in
     resolve_add_conflict acc thing
   in
-  let rec loop blocks (acc : Conf_map.t) : non_block list -> (parser_state, 'b) result =
-    function
+  let rec loop blocks (acc : Conf_map.t) :
+      non_block list -> (parser_state, 'b) result = function
     | (hd : non_block) :: tl -> (
         (* TODO should make sure not to override without conflict resolution,
            ie use addb_unless_bound and so on... *)
@@ -2045,8 +2046,8 @@ let parse_next (effect : parser_effect) initial_state :
                   (Fmt.str "[dev %S] stanza without required [dev-type]" name)
             | _ -> Error "multiple conflicting [dev-type] stanzas present"))
     | [] ->
-      let* acc = List.fold_left block (Ok acc) blocks in
-      Ok (`Done acc : parser_state)
+        let* acc = List.fold_left block (Ok acc) blocks in
+        Ok (`Done acc : parser_state)
   in
   match initial_state with
   | `Done _ as ret -> Ok ret (* already done*)

--- a/src/config.ml
+++ b/src/config.ml
@@ -636,12 +636,12 @@ end
 
 open Conf_map
 
-type line =
+type block = [ `Inline of string * string ]
+type line_no_block =
   [ `Entries of b list
   | `Entry of b
   | `Comment of string
   | `Ignored of string
-  | `Inline of string * string
   | `Keepalive of int * int (* interval * timeout *)
   | `Remote of
     [ `Domain of [ `host ] Domain_name.t * [ `Ipv6 | `Ipv4 | `Any ]
@@ -655,7 +655,9 @@ type line =
   | `Dev of string (* [dev name] stanza requiring a [dev-type]*)
   | `Dev_type of [ `Tun | `Tap ] (* [dev-type] stanza requiring [dev name]*) ]
 
-let pp_line ppf (x : line) =
+type line = [ block | line_no_block ]
+
+let pp_line ppf (x : [< line ]) =
   let v = Fmt.pf in
   match x with
   | `Remote (host, port, proto) ->
@@ -1622,7 +1624,7 @@ let parse_internal config_str : (line list, 'x) result =
                     (Printf.sprintf "Error at byte offset %d: %S" pos context)
                 ))
 
-type parser_partial_state = line list * Conf_map.t
+type parser_partial_state = block list * line_no_block list * Conf_map.t
 
 type parser_state =
   [ `Done of Conf_map.t
@@ -1835,9 +1837,29 @@ let valid_server_options ~client:_ _server_t =
 let parse_next (effect : parser_effect) initial_state :
     (parser_state, 'err) result =
   let open Result.Syntax in
-  let rec loop (acc : Conf_map.t) : line list -> (parser_state, 'b) result =
+  let block acc (`Inline (kind, payload)) =
+    let* acc = acc in
+    (* These are <inlines> that were not declared with an [inline];
+       so fill in default values *)
+    let* kind =
+      match kind with
+      | "auth-user-pass" -> Ok `Auth_user_pass
+      | "ca" -> Ok `Ca
+      | "connection" -> Ok `Connection
+      | "pkcs12" -> Ok `Pkcs12
+      | "tls-auth" -> Ok (`Tls_auth None)
+      | "cert" -> Ok `Tls_cert
+      | "key" -> Ok `Tls_key
+      | "secret" -> Ok (`Secret None)
+      | "tls-crypt-v2" -> Ok (`Tls_crypt_v2 false)
+      | _ -> Error ("Unknown inline kind " ^ kind)
+    in
+    let* thing = parse_inline payload kind in
+    resolve_add_conflict acc thing
+  in
+  let rec loop blocks (acc : Conf_map.t) : line_no_block list -> (parser_state, 'b) result =
     function
-    | (hd : line) :: tl -> (
+    | (hd : line_no_block) :: tl -> (
         (* TODO should make sure not to override without conflict resolution,
            ie use addb_unless_bound and so on... *)
         let multib ?(tl = tl) kv =
@@ -1852,7 +1874,7 @@ let parse_next (effect : parser_effect) initial_state :
                     Error err)
               (Ok acc) kv
           in
-          loop acc tl
+          loop blocks acc tl
         in
         let retb ?tl b = multib ?tl [ b ] in
         match hd with
@@ -1867,56 +1889,25 @@ let parse_next (effect : parser_effect) initial_state :
                     (parse_inline content kind)
                 in
                 retb r
-            | _ -> Ok (`Need_file (wanted_name, (hd :: tl, acc))))
+            | _ -> Ok (`Need_file (wanted_name, (blocks, hd :: tl, acc))))
         | `Need_inline kind -> (
             let looking_for = string_of_inlineable kind in
             match
               List.partition
-                (function
-                  | `Inline (kind2, _) -> String.equal looking_for kind2
-                  | _ -> false)
-                tl
+                (fun (`Inline (kind2, _)) -> String.equal looking_for kind2)
+                blocks
             with
             | `Inline (_, x) :: inline_tl, other_tl ->
                 Log.debug (fun m -> m "consuming [inline] %s" looking_for);
                 let* thing = parse_inline x kind in
                 let* acc = resolve_add_conflict acc thing in
-                loop acc (other_tl @ inline_tl)
+                (* TODO: this leads to some list shuffling *)
+                loop (other_tl @ inline_tl) acc tl
             | [], _ ->
                 (* TODO if we already have it in the map, we don't need to fail: *)
-                Error ("not found: needed [inline]: " ^ looking_for)
-            | _ -> Error "TODO List.partition was wrong")
-        | `Inline ("connection", x) ->
-            let* thing = parse_inline x `Connection in
-            let* acc = resolve_add_conflict acc thing in
-            loop acc tl
-        | `Inline ("secret", payload) ->
-            (* If there's a "secret [inline] dir" earlier this doesn't trigger inshallah *)
-            let* thing = parse_inline payload (`Secret None) in
-            let* acc = resolve_add_conflict acc thing in
-            loop acc tl
-        | `Inline (fname, _) ->
-            (* Except for "connection" all blocks must be warranted by an
-               [inline] value in a matching directive. If we have one, we move
-               this block to the end of the list (since we -know- it's needed).
-               If not, we ignore it after emitting an error: *)
-            loop acc @@ tl
-            @
-            if
-              List.exists
-                (function
-                  | `Need_inline k
-                    when String.equal fname (string_of_inlineable k) ->
-                      true
-                  | _ -> false)
-                tl
-            then [ hd ]
-            else (
-              Log.warn (fun m ->
-                  m "Inline block %S seems to be redundant" fname);
-              [])
-        | `Ignored _ -> loop acc tl
-        | `Comment _ -> loop acc tl
+                Error ("not found: needed [inline]: " ^ looking_for))
+        | `Ignored _ -> loop blocks acc tl
+        | `Comment _ -> loop blocks acc tl
         | `Rport _ as this_directive ->
             (* The parser for `Remote will look for `Rport when needed.
                To avoid an endless loop here we ignore the present `Rport
@@ -1942,7 +1933,7 @@ let parse_next (effect : parser_effect) initial_state :
                     | _ -> compare a b)
                   (this_directive :: tl)
               in
-              loop acc sorted_tl
+              loop blocks acc sorted_tl
         | `Entry b -> retb b
         | `Entries lst -> multib lst
         | `Keepalive (interval, timeout) ->
@@ -1984,7 +1975,7 @@ let parse_next (effect : parser_effect) initial_state :
               in
               keepalive_action was_old timeout action
             in
-            loop (add Ping_timeout timeout acc) tl
+            loop blocks (add Ping_timeout timeout acc) tl
         | (`Proto_force _ | `Socks_proxy _) as line ->
             Log.warn (fun m ->
                 m "ignoring unimplemented option: %a" pp_line line);
@@ -2040,7 +2031,7 @@ let parse_next (effect : parser_effect) initial_state :
                 (* extraneous dev-type stanzas when dev-type has already been
                    inferred from the device name, e.g. "tun0" *)
                 match find Dev acc with
-                | Some (typ2, _name) when typ = typ2 -> loop acc tl
+                | Some (typ2, _name) when typ = typ2 -> loop blocks acc tl
                 | Some (_, _name) ->
                     Error
                       (Fmt.str
@@ -2053,17 +2044,28 @@ let parse_next (effect : parser_effect) initial_state :
                 Error
                   (Fmt.str "[dev %S] stanza without required [dev-type]" name)
             | _ -> Error "multiple conflicting [dev-type] stanzas present"))
-    | [] -> Ok (`Done acc : parser_state)
+    | [] ->
+      let* acc = List.fold_left block (Ok acc) blocks in
+      Ok (`Done acc : parser_state)
   in
   match initial_state with
   | `Done _ as ret -> Ok ret (* already done*)
-  | `Partial (lines, acc) -> loop acc lines
-  | `Need_file (_fn, (lines, acc)) -> loop acc lines
+  | `Partial (blocks, lines, acc) -> loop blocks acc lines
+  | `Need_file (_fn, (blocks, lines, acc)) -> loop blocks acc lines
 
 let parse_begin config_str : (parser_state, 'err) result =
   let open Result.Syntax in
   let* lines = parse_internal config_str in
-  parse_next None (`Partial (lines, empty))
+  let blocks, non_blocks =
+    (* List.partition (function `Inline _ -> true | _ -> false) lines *)
+    let rec loop (blocks, non_blocks) = function
+      | `Inline _ as block :: tl -> loop (block :: blocks, non_blocks) tl
+      | (#line_no_block as non_block) :: tl -> loop (blocks, non_block :: non_blocks) tl
+      | [] -> (List.rev blocks, List.rev non_blocks)
+    in
+    loop ([], []) lines
+  in
+  parse_next None (`Partial (blocks, non_blocks, empty))
 
 let parse ~string_of_file config_str : (Conf_map.t, [> `Msg of string ]) result
     =

--- a/test/config_tests.ml
+++ b/test/config_tests.ml
@@ -502,7 +502,9 @@ let client_conf =
   |> add Tls_auth tls_auth |> add Cipher `AES_256_CBC |> add Verb 3
 
 let static_client_conf, inline_secret_direction =
-  let k_a, k_b, k_c, k_d = a_inline_payload {|
+  let k_a, k_b, k_c, k_d =
+    a_inline_payload
+      {|
 -----BEGIN OpenVPN Static key V1-----
 87055d27a5536ac72e129916f4287adb
 fce68b7ef6d929539ea170ed0ddf6822
@@ -527,12 +529,13 @@ f508feaf3818d8bb35d0afea0e609681
     minimal_config |> remove Auth_user_pass |> remove Tls_mode
     |> add Dev (`Tun, None)
     |> add Proto (None, `Udp)
-    |> add Remote [ ( `Ip (Ipaddr.of_string_exn "1.2.3.4"), 1194, `Udp ); ]
+    |> add Remote [ (`Ip (Ipaddr.of_string_exn "1.2.3.4"), 1194, `Udp) ]
     |> add Verb 3
-    |> add Ifconfig (Ipaddr.of_string_exn "10.1.0.2", Ipaddr.of_string_exn "10.1.0.1")
+    |> add Ifconfig
+         (Ipaddr.of_string_exn "10.1.0.2", Ipaddr.of_string_exn "10.1.0.1")
     |> add Secret (None, k_a, k_b, k_c, k_d)
   in
-  cfg, cfg |> add Secret (Some `Outgoing, k_a, k_b, k_c, k_d)
+  (cfg, cfg |> add Secret (Some `Outgoing, k_a, k_b, k_c, k_d))
 
 let tls_home_conf =
   let open Miragevpn.Config in
@@ -732,16 +735,20 @@ let tests =
       parse_client_configuration ~config:client_conf "client.conf" );
     ( "parsing configuration 'static-home'",
       `Quick,
-      parse_client_configuration ~config:static_client_conf "static-home.conf" );
+      parse_client_configuration ~config:static_client_conf "static-home.conf"
+    );
     ( "parsing configuration 'static-home-inline-secret'",
       `Quick,
-      parse_client_configuration ~config:static_client_conf "static-home-inline-secret.conf" );
+      parse_client_configuration ~config:static_client_conf
+        "static-home-inline-secret.conf" );
     ( "parsing configuration 'inline-secret-direction'",
       `Quick,
-      parse_client_configuration ~config:inline_secret_direction "inline-secret-direction.conf" );
+      parse_client_configuration ~config:inline_secret_direction
+        "inline-secret-direction.conf" );
     ( "parsing configuration 'inline-secret-direction-reverse'",
       `Quick,
-      parse_client_configuration ~config:inline_secret_direction "inline-secret-direction-reverse.conf" );
+      parse_client_configuration ~config:inline_secret_direction
+        "inline-secret-direction-reverse.conf" );
     ( "parsing configuration 'tls-home'",
       `Quick,
       parse_client_configuration ~config:tls_home_conf "tls-home.conf" );

--- a/test/sample-configuration-files/inline-secret-direction-reverse.conf
+++ b/test/sample-configuration-files/inline-secret-direction-reverse.conf
@@ -1,0 +1,30 @@
+dev tun
+remote 1.2.3.4
+ifconfig 10.1.0.2 10.1.0.1
+cipher AES-256-CBC
+verb 3
+
+<secret>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+87055d27a5536ac72e129916f4287adb
+fce68b7ef6d929539ea170ed0ddf6822
+899f5dbe6aa5df17673c10d63bfe5221
+a25824527c60187666406d92c18dfc3a
+ec597ed09c5aaacc2256c2303e71e17e
+ff995ce7760877abee1d400ea768ace6
+3dcc7d0ef10f1f6d4df4822a78ebbf87
+99e1ddcf2e206872235eb7a92fddd560
+99654cb6d0d19dc099fdfe318382c5b8
+f508feaf3818d8bb35d0afea0e609681
+8d7eaf4dc8ee072188c414405d6a0ec7
+079d4faaf8520e77eee535e4cc0c7785
+5f70cc929d9b5fcbab6e939c088962e4
+7fe05b2e4367c15ddf8f1824b7d772a6
+668345bc7b2f847d03080abb59ff37f2
+1f7c6528d77584af997c0779a1c7e36f
+-----END OpenVPN Static key V1-----
+</secret>
+secret [inline] 0

--- a/test/sample-configuration-files/inline-secret-direction.conf
+++ b/test/sample-configuration-files/inline-secret-direction.conf
@@ -1,0 +1,30 @@
+dev tun
+remote 1.2.3.4
+ifconfig 10.1.0.2 10.1.0.1
+secret [inline] 0
+cipher AES-256-CBC
+verb 3
+
+<secret>
+#
+# 2048 bit OpenVPN static key
+#
+-----BEGIN OpenVPN Static key V1-----
+87055d27a5536ac72e129916f4287adb
+fce68b7ef6d929539ea170ed0ddf6822
+899f5dbe6aa5df17673c10d63bfe5221
+a25824527c60187666406d92c18dfc3a
+ec597ed09c5aaacc2256c2303e71e17e
+ff995ce7760877abee1d400ea768ace6
+3dcc7d0ef10f1f6d4df4822a78ebbf87
+99e1ddcf2e206872235eb7a92fddd560
+99654cb6d0d19dc099fdfe318382c5b8
+f508feaf3818d8bb35d0afea0e609681
+8d7eaf4dc8ee072188c414405d6a0ec7
+079d4faaf8520e77eee535e4cc0c7785
+5f70cc929d9b5fcbab6e939c088962e4
+7fe05b2e4367c15ddf8f1824b7d772a6
+668345bc7b2f847d03080abb59ff37f2
+1f7c6528d77584af997c0779a1c7e36f
+-----END OpenVPN Static key V1-----
+</secret>


### PR DESCRIPTION
This addresses #167 by splitting the lines into inline blocks and non-inline blocks. First the non-inline blocks are processed optionally consuming inline blocks if they are `` `Need_inline _ ``, then any remaining inline blocks are processed using default values for optional arguments.