### PR TITLE
Print session IDs as hex

### DIFF
--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1030,8 +1030,8 @@ let pp_error ppf = function
       Fmt.pf ppf "mismatched their session id: expected %016LX, received %016LX"
         expected received
   | `Mismatch_my_session_id (expected, received) ->
-      Fmt.pf ppf "mismatched my session id: expected %016LX, received %016LX" expected
-        received
+      Fmt.pf ppf "mismatched my session id: expected %016LX, received %016LX"
+        expected received
   | `Bad_mac (state, computed, data) ->
       Fmt.pf ppf "bad mac: computed %a data %a@ (state %a)" Cstruct.hexdump_pp
         computed Packet.pp data pp state

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1027,10 +1027,10 @@ let pp_error ppf = function
       Fmt.pf ppf "non monotonic sequence number: expected %lu, received %lu"
         expected received
   | `Mismatch_their_session_id (expected, received) ->
-      Fmt.pf ppf "mismatched their session id: expected %Lu, received %Lu"
+      Fmt.pf ppf "mismatched their session id: expected %Lx, received %Lx"
         expected received
   | `Mismatch_my_session_id (expected, received) ->
-      Fmt.pf ppf "mismatched my session id: expected %Lu, received %Lu" expected
+      Fmt.pf ppf "mismatched my session id: expected %Lx, received %Lx" expected
         received
   | `Bad_mac (state, computed, data) ->
       Fmt.pf ppf "bad mac: computed %a data %a@ (state %a)" Cstruct.hexdump_pp

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1027,10 +1027,10 @@ let pp_error ppf = function
       Fmt.pf ppf "non monotonic sequence number: expected %lu, received %lu"
         expected received
   | `Mismatch_their_session_id (expected, received) ->
-      Fmt.pf ppf "mismatched their session id: expected %Lx, received %Lx"
+      Fmt.pf ppf "mismatched their session id: expected %016LX, received %016LX"
         expected received
   | `Mismatch_my_session_id (expected, received) ->
-      Fmt.pf ppf "mismatched my session id: expected %Lx, received %Lx" expected
+      Fmt.pf ppf "mismatched my session id: expected %016LX, received %016LX" expected
         received
   | `Bad_mac (state, computed, data) ->
       Fmt.pf ppf "bad mac: computed %a data %a@ (state %a)" Cstruct.hexdump_pp

--- a/src/state.ml
+++ b/src/state.ml
@@ -222,8 +222,8 @@ let init_session ~my_session_id ?(their_session_id = 0L) ?(compress = false)
 
 let pp_session ppf t =
   Fmt.pf ppf
-    "compression %B@ protocol %a@ my session %Lx@ replay %lu@ their session \
-     %Lx@ replay %lu"
+    "compression %B@ protocol %a@ my session %016LX@ replay %lu@ their session \
+     %016LX@ replay %lu"
     t.compress pp_proto t.protocol t.my_session_id t.my_replay_id
     t.their_session_id t.their_replay_id
 

--- a/src/state.ml
+++ b/src/state.ml
@@ -222,8 +222,8 @@ let init_session ~my_session_id ?(their_session_id = 0L) ?(compress = false)
 
 let pp_session ppf t =
   Fmt.pf ppf
-    "compression %B@ protocol %a@ my session %Lu@ replay %lu@ their session \
-     %Lu@ replay %lu"
+    "compression %B@ protocol %a@ my session %Lx@ replay %lu@ their session \
+     %Lx@ replay %lu"
     t.compress pp_proto t.protocol t.my_session_id t.my_replay_id
     t.their_session_id t.their_replay_id
 


### PR DESCRIPTION
This is what OpenVPN does, and a random int64 gets pretty long when printed as hexadecimal.