### PR TITLE
Ignore reneg* = 0

### DIFF
--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1214,10 +1214,10 @@ let maybe_rekey state =
     with
     | Some y, _, _
       when y <= Duration.to_sec (Int64.sub (state.ts ()) state.channel.started)
-      ->
+           && y > 0 ->
         true
-    | _, Some b, _ when b <= state.channel.bytes -> true
-    | _, _, Some p when p <= state.channel.packets -> true
+    | _, Some b, _ when b <= state.channel.bytes && b > 0 -> true
+    | _, _, Some p when p <= state.channel.packets && p > 0 -> true
     | _ -> false
   in
   if should_rekey then maybe_init_rekey state else (state, [])


### PR DESCRIPTION
We could as well remove the config values if they are zero. But it may be easier to use zero as a special value as we need to negotiate these values with the server (or client).

The special meaning of 0 is only properly documented in the man page for `--reneg-bytes` but the code shows that is applies to `--reneg-pkts` and `--reneg-sec` too:
https://github.com/OpenVPN/openvpn/blob/8656b85c7324fc9ae7f10a9f37227a58766aae33/src/openvpn/ssl.c#L2884-L2893