### PR TITLE
Config.client_generate_connect_options: only emit "auth" if tls-auth is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ is specified.  If it is desired to use the certificates from the PKCS#12 file
 to authenticate the remote the certificates can be added with the "ca" option
 by extracting the certificates with e.g. `openssl pkcs12`.
 
+For tls clients (as opposed to static key clients) we only support data channel
+AEAD ciphers. This means the `--auth` option is ignored for data channel
+authentication for tls clients. For `--tls-auth` it is still used to choose the
+hmac used for the control channel while for `--tls-crypt` and `--tls-crypt-v2`
+the hmac is hardcoded (as per OpenVPN™).
+
 ## Funding
 
 This project was funded in 2019 for six months by the [German federal ministry for education and research](https://www.bmbf.de) via the [Prototypefund](https://prototypefund.de) - the amount was 47500 EUR.

--- a/src/config.ml
+++ b/src/config.ml
@@ -2278,7 +2278,11 @@ let client_generate_connect_options t =
         | B (Link_mtu, _) -> true
         | B (Pull, _) -> true
         | B (Tls_mode, `Client) -> true
-        | B (Auth, _) -> true
+        | B (Auth, _) ->
+            not
+              (Conf_map.mem Tls_crypt t
+              || Conf_map.mem Tls_crypt_v2_client t
+              || Conf_map.mem Tls_crypt_v2_server t)
         | _ -> false)
       t
   in

--- a/src/config.ml
+++ b/src/config.ml
@@ -2278,7 +2278,8 @@ let client_generate_connect_options t =
         | B (Link_mtu, _) -> true
         | B (Pull, _) -> true
         | B (Tls_mode, `Client) -> true
-        | B (Auth, _) -> Conf_map.mem Tls_auth t
+        | B (Auth, _) ->
+            Conf_map.mem Tls_auth t
             (* Assumption: we only support AEAD ciphers in tls clients. Thus
                [Auth] option is ignored for the data channel, and for
                tls-crypt(-v2) the hmac is hardcoded. For tls-auth we still want

--- a/src/config.ml
+++ b/src/config.ml
@@ -2284,10 +2284,6 @@ let client_generate_connect_options t =
                tls-crypt(-v2) the hmac is hardcoded. For tls-auth we still want
                to send it because it is used for authenticating the control
                channel *)
-            not
-              (Conf_map.mem Tls_crypt t
-              || Conf_map.mem Tls_crypt_v2_client t
-              || Conf_map.mem Tls_crypt_v2_server t)
         | _ -> false)
       t
   in

--- a/src/config.ml
+++ b/src/config.ml
@@ -2278,7 +2278,7 @@ let client_generate_connect_options t =
         | B (Link_mtu, _) -> true
         | B (Pull, _) -> true
         | B (Tls_mode, `Client) -> true
-        | B (Auth, _) ->
+        | B (Auth, _) -> Conf_map.mem Tls_auth t
             (* Assumption: we only support AEAD ciphers in tls clients. Thus
                [Auth] option is ignored for the data channel, and for
                tls-crypt(-v2) the hmac is hardcoded. For tls-auth we still want

--- a/src/config.ml
+++ b/src/config.ml
@@ -2279,6 +2279,11 @@ let client_generate_connect_options t =
         | B (Pull, _) -> true
         | B (Tls_mode, `Client) -> true
         | B (Auth, _) ->
+            (* Assumption: we only support AEAD ciphers in tls clients. Thus
+               [Auth] option is ignored for the data channel, and for
+               tls-crypt(-v2) the hmac is hardcoded. For tls-auth we still want
+               to send it because it is used for authenticating the control
+               channel *)
             not
               (Conf_map.mem Tls_crypt t
               || Conf_map.mem Tls_crypt_v2_client t


### PR DESCRIPTION
Previously, "auth SHA1" was sent to servers when tls-crypt{,v2} was used