### PR TITLE
UDP and eduvpn

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -1595,6 +1595,8 @@ let a_not_implemented =
       string "up";
       string "dh";
       string "explicit-exit-notify";
+      string "tun-ipv6";
+      string "ifconfig-ipv6";
     ]
   >>= fun key ->
   a_line not_control_char >>| fun rest ->


### PR DESCRIPTION
This makes a UDP client ignore packets that are: partial, has a bad MAC, violates the replay id or sequence number.

This is perhaps a bit too naïve. The client will "accept" and ignore any number of bad packets. Then again I don't know what else to do. I *think* OpenVPN silently ignores packets that are within the replay window and otherwise loudly warns about packet replays (but otherwise doesn't do anything I think).

I am trying to understand how the replay window and packet reordering is supposed to work. The replay window seems to work on the replay id, but for the packet reordering I'm unsure how that is supposed to work. The terminology in the openvpn rfc, documentation and code is very muddy and uses "packet id" both for replay id and the sequence number etc. That will be for another PR.