### PR TITLE
Remove evaluated Cstruct.hexdump_pp on guards which slow down our process

### DIFF
--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1266,7 +1266,8 @@ let incoming_data ?(add_timestamp = false) err (ctx : keys) hmac_algorithm
         let* () =
           guard
             (Cstruct.length dec >= hdr_len)
-            (Result.msgf "payload too short (need %u bytes): %u" hdr_len (Cstruct.length dec))
+            (Result.msgf "payload too short (need %u bytes): %u" hdr_len
+               (Cstruct.length dec))
         in
         (* TODO validate replay packet id and ordering *)
         Log.debug (fun m ->

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1266,7 +1266,7 @@ let incoming_data ?(add_timestamp = false) err (ctx : keys) hmac_algorithm
         let* () =
           guard
             (Cstruct.length dec >= hdr_len)
-            (Result.msgf "payload too short (need %d bytes)" hdr_len)
+            (Result.msgf "payload too short (need %u bytes): %u" hdr_len (Cstruct.length dec))
         in
         (* TODO validate replay packet id and ordering *)
         Log.debug (fun m ->
@@ -1278,8 +1278,8 @@ let incoming_data ?(add_timestamp = false) err (ctx : keys) hmac_algorithm
         let* () =
           guard
             (Cstruct.length data >= Packet.id_len + tag_len)
-            (Result.msgf "payload too short (need %d bytes)"
-               (Packet.id_len + tag_len))
+            (Result.msgf "payload too short (need %u bytes): %u"
+               (Packet.id_len + tag_len) (Cstruct.length data))
         in
         let replay_id, tag, payload =
           let sn, rest = Cstruct.split data Packet.id_len in
@@ -1301,8 +1301,8 @@ let incoming_data ?(add_timestamp = false) err (ctx : keys) hmac_algorithm
         let* () =
           guard
             (Cstruct.length data >= Packet.id_len + tag_len)
-            (Result.msgf "payload too short (need %d bytes)"
-               (Packet.id_len + tag_len))
+            (Result.msgf "payload too short (need %u bytes): %u"
+               (Packet.id_len + tag_len) (Cstruct.length data))
         in
         let replay_id, tag, payload =
           let sn, rest = Cstruct.split data Packet.id_len in

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1266,8 +1266,7 @@ let incoming_data ?(add_timestamp = false) err (ctx : keys) hmac_algorithm
         let* () =
           guard
             (Cstruct.length dec >= hdr_len)
-            (Result.msgf "payload too short (need %d bytes): %a" hdr_len
-               Cstruct.hexdump_pp dec)
+            (Result.msgf "payload too short (need %d bytes)" hdr_len)
         in
         (* TODO validate replay packet id and ordering *)
         Log.debug (fun m ->
@@ -1279,8 +1278,8 @@ let incoming_data ?(add_timestamp = false) err (ctx : keys) hmac_algorithm
         let* () =
           guard
             (Cstruct.length data >= Packet.id_len + tag_len)
-            (Result.msgf "payload too short (need %d bytes): %a"
-               (Packet.id_len + tag_len) Cstruct.hexdump_pp data)
+            (Result.msgf "payload too short (need %d bytes)"
+               (Packet.id_len + tag_len))
         in
         let replay_id, tag, payload =
           let sn, rest = Cstruct.split data Packet.id_len in
@@ -1302,8 +1301,8 @@ let incoming_data ?(add_timestamp = false) err (ctx : keys) hmac_algorithm
         let* () =
           guard
             (Cstruct.length data >= Packet.id_len + tag_len)
-            (Result.msgf "payload too short (need %d bytes): %a"
-               (Packet.id_len + tag_len) Cstruct.hexdump_pp data)
+            (Result.msgf "payload too short (need %d bytes)"
+               (Packet.id_len + tag_len))
         in
         let replay_id, tag, payload =
           let sn, rest = Cstruct.split data Packet.id_len in


### PR DESCRIPTION
Currently, these `Cstruct‧hexdump_pp` are evaluated in any case (the error case and the good case). They slow down our process. This PR remove them (we loose some informations but that's fine).