### PR TITLE
Avoid copying buffer when linger is empty

### DIFF
--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1969,7 +1969,14 @@ let handle_static_client t s keys ev =
                   let acc = Option.fold d ~none:acc ~some:(fun p -> p :: acc) in
                   process_one acc linger
           in
-          let+ t, payloads = process_one [] (Cstruct.append t.linger cs) in
+          let+ t, payloads =
+            let cs =
+              if Cstruct.is_empty t.linger then
+                cs
+              else
+                Cstruct.append t.linger cs
+            in
+            process_one [] cs in
           (t, [], List.rev payloads, None)
       | s, ev ->
           Result.error_msgf


### PR DESCRIPTION
`Cstruct.append Cstruct.empty buf` results in a _copy_ of `buf`. This is wasteful, so let's avoid it.

The performance difference is barely measurable, at least on my noisy laptop.