### PR TITLE
Rename Cstruct_ext.concat_with_empty_prefix

### DIFF
--- a/src/cstruct_ext.ml
+++ b/src/cstruct_ext.ml
@@ -19,10 +19,9 @@ let append' cs cs' =
   else if Cstruct.is_empty cs' then cs
   else Cstruct.append cs cs'
 
-let concat_with_empty_prefix prefix_len css =
+let concat_with_unsafe_prefix prefix_len css =
   let len = prefix_len + Cstruct.lenv css in
   let b = Cstruct.create_unsafe len in
-  Cstruct.memset (Cstruct.sub b 0 prefix_len) 0;
   let _ : int =
     List.fold_left
       (fun off cs ->

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1073,7 +1073,7 @@ let out ?add_timestamp prefix_len (ctx : keys) hmac_algorithm compress rng data
     let enc, tag =
       authenticate_encrypt_tag ~key:my_key ~nonce ~adata:replay_id data
     in
-    Cstruct_ext.concat_with_empty_prefix prefix_len [ replay_id; tag; enc ]
+    Cstruct_ext.concat_with_unsafe_prefix prefix_len [ replay_id; tag; enc ]
   in
   ( { ctx with my_replay_id = Int32.succ ctx.my_replay_id },
     match ctx.keys with
@@ -1113,7 +1113,7 @@ let out ?add_timestamp prefix_len (ctx : keys) hmac_algorithm compress rng data
               feed iv;
               feed enc)
         in
-        Cstruct_ext.concat_with_empty_prefix prefix_len [ hmac; iv; enc ]
+        Cstruct_ext.concat_with_unsafe_prefix prefix_len [ hmac; iv; enc ]
     | AES_GCM { my_key; my_implicit_iv; _ } ->
         aead Mirage_crypto.Cipher_block.AES.GCM.authenticate_encrypt_tag my_key
           my_implicit_iv


### PR DESCRIPTION
Into Cstruct_ext.concat_with_unsafe_prefix and do not memset the prefix.