### PR TITLE
Keep TLS state when established

### DIFF
--- a/src/state.ml
+++ b/src/state.ml
@@ -67,7 +67,7 @@ type channel_state =
   | TLS_handshake of Tls.Engine.state
   | TLS_established of Tls.Engine.state * my_key_material
   | Push_request_sent of Tls.Engine.state * my_key_material * Packet.tls_data
-  | Established of keys
+  | Established of Tls.Engine.state * keys
 
 let pp_channel_state ppf = function
   | Expect_reset -> Fmt.string ppf "expecting reset"
@@ -104,11 +104,13 @@ let new_channel ?(state = Expect_reset) keyid started =
   }
 
 let keys_opt ch =
-  match ch.channel_st with Established keys -> Some keys | _ -> None
+  match ch.channel_st with Established (_tls, keys) -> Some keys | _ -> None
 
 let set_keys ch keys =
   let channel_st =
-    match ch.channel_st with Established _ -> Established keys | x -> x
+    match ch.channel_st with
+    | Established (tls, _) -> Established (tls, keys)
+    | x -> x
   in
   { ch with channel_st }
 


### PR DESCRIPTION
We currently will not use the TLS state once established, but if we implement exit control messages we will need to keep the TLS state around.

We may not need the TLS state if exitcc is not negotiated. In that case we can reiterate and make it an option.