### PR TITLE
When `Established _` read incoming control channel messages

### DIFF
--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1604,11 +1604,9 @@ let send_control_message s data =
             Cstruct.blit_from_string data 0 data' 0 (String.length data);
             Cstruct.set_uint8 data' (String.length data) 0;
             let* tls, out =
-              Option.to_result
-                ~none:
-                  (`Msg
-                    "Tls.send application data failed for control channel \
-                     message")
+              (* reynir: I *think* it only returns [None] when not established
+                 or after write is shutdown. *)
+              Option.to_result ~none:`Not_ready
                 (Tls.Engine.send_application_data tls [ data' ])
             in
             Ok (Established (tls, keys), (`Control, out))

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1847,7 +1847,7 @@ let resolve_connect_client t ts s ev =
     (r, next)
   and retry_exceeded r =
     match Config.get Connect_retry_max t.config with
-    | `Times m -> m > r
+    | `Times m -> r >= m
     | `Unlimited -> false
   in
   let next_or_fail t idx retry =

--- a/src/miragevpn.mli
+++ b/src/miragevpn.mli
@@ -326,6 +326,10 @@ val outgoing : t -> Cstruct.t -> (t * Cstruct.t, [ `Not_ready ]) result
 (** [outgoing t data] prepares [data] to be sent over the OpenVPN connection.
     If the connection is not ready yet, [`Not_ready] is returned instead. *)
 
+val send_control_message :
+  t -> string -> (t * Cstruct.t list, [ `Not_ready | `Msg of string ]) result
+(** [send_control_message t message] sends [message] over the control channel. *)
+
 val new_connection : server -> t
 (** [new_connection server] is to be called when the server accepted a new
     TCP connection, a state [t] is constructed - which can be used with

--- a/src/miragevpn.mli
+++ b/src/miragevpn.mli
@@ -327,7 +327,7 @@ val outgoing : t -> Cstruct.t -> (t * Cstruct.t, [ `Not_ready ]) result
     If the connection is not ready yet, [`Not_ready] is returned instead. *)
 
 val send_control_message :
-  t -> string -> (t * Cstruct.t list, [ `Not_ready | `Msg of string ]) result
+  t -> string -> (t * Cstruct.t list, [ `Not_ready ]) result
 (** [send_control_message t message] sends [message] over the control channel. *)
 
 val new_connection : server -> t

--- a/src/packet.ml
+++ b/src/packet.ml
@@ -666,9 +666,13 @@ let push_request = Cstruct.of_string "PUSH_REQUEST\x00"
 let push_reply = Cstruct.of_string "PUSH_REPLY"
 
 module Iv_proto = struct
-  type t = Request_push | Tls_key_export
+  type t = Request_push | Tls_key_export | Use_cc_exit_notify
 
-  let bit = function Request_push -> 2 | Tls_key_export -> 3
+  let bit = function
+    | Request_push -> 2
+    | Tls_key_export -> 3
+    | Use_cc_exit_notify -> 6
+
   let byte xs = List.fold_left (fun b x -> b lor (1 lsl bit x)) 0 xs
   let contains flag v = v land (1 lsl bit flag) <> 0
 end


### PR DESCRIPTION
When the openvpn tunnel is established keep reading control channel messages. For now we just warn about unknown control messages and do nothing. The [OpenVPN implementation](https://github.com/OpenVPN/openvpn/blob/32e6586687a548174b88b64fe54bfae6c74d4c19/src/openvpn/forward.c#L233-L301) also just warns for unknown control messages it seems. I may extend this PR to handle exit and restart messages. 

The `EXIT` and `RESTART` control channel messages are only emitted by OpenVPN when using UDP. Therefore I have only tested it with our miragevpn-client-notun connecting to an OpenVPN server with `--explicit-exit-notify`. Restarting the OpenVPN service resulted in a warning about an unknown control channel message `"RESTART\000"` and the client kept trying to send pings in the VPN. This is different than from before where it would fail with "no transition found". I am not sure this is actually desirable...