### PR TITLE
Server tls-ekm negotiation

### DIFF
--- a/src/config.ml
+++ b/src/config.ml
@@ -920,8 +920,8 @@ let a_proto_force =
   >>| fun prot -> `Proto_force prot
 
 let a_protocol_flags =
-  string "protocol-flags" *> a_whitespace *> commit
-  *> sep_by a_whitespace a_single_param
+  string "protocol-flags"
+  *> option [] (a_whitespace *> commit *> sep_by a_whitespace a_single_param)
   >>| fun flags ->
   let flags =
     List.filter_map

--- a/src/config.ml
+++ b/src/config.ml
@@ -2372,8 +2372,6 @@ let client_generate_connect_options t =
   (* Ok "V4,dev-type tun,link-mtu 1560,tun-mtu 1500,proto TCPv4_CLIENT,\
      keydir 1,cipher AES-256-CBC,auth SHA1,keysize 256,tls-auth,\
      key-method 2" *)
-  let open Result.Syntax in
-  let* () = Conf_map.is_valid_client_config t in
   let excerpt =
     Conf_map.filter
       (function
@@ -2398,7 +2396,7 @@ let client_generate_connect_options t =
       (Conf_map.pp_with_sep ~sep:(Fmt.any ","))
       excerpt
   in
-  Ok serialized
+  serialized
 
 let server_generate_connect_options config =
   Fmt.str

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -597,6 +597,10 @@ let kex_server config session (my_key_material : my_key_material) tls data =
       then Config.add_protocol_flag `Tls_ekm config
       else config
     in
+    (* XXX(reynir): if a client supports tls-ekm and set [Use_cc_exit_notify]
+       it is unnecessary to use 'key-derivation tls-ekm' in addition to
+       'protocol-flags tls-ekm'. In that case 'protocol-flags tls-ekm' is
+       sufficient. *)
     if supports_tls_ekm then Config.add Key_derivation `Tls_ekm config
     else config
   in

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -178,6 +178,7 @@ let tls_crypt_v2 config =
 let client ?pkcs12_password config ts now rng =
   let open Result.Syntax in
   let current_ts = ts () in
+  let* () = Config.is_valid_client_config config in
   let config =
     match Config.get Remote_random config with
     | exception Not_found -> config
@@ -314,6 +315,7 @@ let client ?pkcs12_password config ts now rng =
 
 let server server_config ~is_not_taken server_ts server_now server_rng =
   let open Result.Syntax in
+  let* () = Config.is_valid_server_config server_config in
   let port = Option.value ~default:1194 (Config.find Port server_config) in
   let+ tls_auth = tls_auth server_config in
   ( { server_config; is_not_taken; server_rng; server_ts; server_now; tls_auth },
@@ -438,7 +440,7 @@ let maybe_kex_client rng config tls =
   if Tls.Engine.handshake_in_progress tls then Ok (TLS_handshake tls, None)
   else
     let pre_master, random1, random2 = (rng 48, rng 32, rng 32) in
-    let* options = Config.client_generate_connect_options config in
+    let options = Config.client_generate_connect_options config in
     let pull = Config.mem Pull config in
     let user_pass = Config.find Auth_user_pass config in
     let peer_info =

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -584,8 +584,10 @@ let kex_server config session (my_key_material : my_key_material) tls data =
   let config = Config.add Cipher (cipher :> Config.cipher) config in
   let config =
     let supports_tls_ekm =
-      Option.fold iv_proto ~none:false
-        ~some:Packet.Iv_proto.(contains Tls_key_export)
+      (* See issue 181, doesn't work with TLS 1.3 *)
+      false
+      && Option.fold iv_proto ~none:false
+           ~some:Packet.Iv_proto.(contains Tls_key_export)
     in
     let config =
       if

--- a/src/miragevpn.mli
+++ b/src/miragevpn.mli
@@ -217,11 +217,6 @@ module Config : sig
   val eq : eq
   (** [eq] is an implementation of [cmp] for use with [{!equal} cmp t t2] *)
 
-  val client_generate_connect_options :
-    t -> (string, [> `Msg of string ]) result
-  (** Exports the excerpts from the client configuration sent to the server
-      when the client initially connects. *)
-
   val client_merge_server_config :
     t -> string -> (t, [> `Msg of string ]) result
   (** Apply config excerpt from server received upon initial connection.

--- a/src/miragevpn.mli
+++ b/src/miragevpn.mli
@@ -3,6 +3,12 @@ module Config : sig
 
   type flag = unit
 
+  module Protocol_flag : sig
+    type t
+
+    val to_string : t -> string
+  end
+
   type 'a k =
     | Auth : Mirage_crypto.Hash.hash k
     | Auth_nocache : flag k
@@ -108,6 +114,7 @@ module Config : sig
         : ([ `Ipv6 | `Ipv4 ] option
           * [ `Udp | `Tcp of [ `Server | `Client ] option ])
           k  (** TODO should Proto be bound to a remote? *)
+    | Protocol_flags : Protocol_flag.t list k
     | Remote
         : ([ `Domain of [ `host ] Domain_name.t * [ `Ipv4 | `Ipv6 | `Any ]
            | `Ip of Ipaddr.t ]


### PR DESCRIPTION
This implements tls-ekm negotiation in the server. With this change I am able to reproduce #181 in the miragevpn-server-notun both with OpenVPN client and our Miragevpn client **when using tls 1.3**. When using tls 1.2 it works just fine with both clients.