### PR TITLE
Use key method mask

### DIFF
--- a/src/packet.ml
+++ b/src/packet.ml
@@ -547,6 +547,9 @@ let pp_tls_data ppf t =
 
 let key_method = 0x02
 
+(* For some reason OpenVPN only looks at the lower half of the byte *)
+let key_method_mask = 0x0f
+
 (* strings are
    (a) length-prefixed (2 bytes, big endian);
    (b) terminated with 0 byte;
@@ -615,7 +618,7 @@ let decode_tls_data ?(with_premaster = false) buf =
   in
   let* () =
     guard
-      (Cstruct.get_uint8 buf 4 = key_method)
+      (Cstruct.get_uint8 buf 4 land key_method_mask = key_method)
       (`Malformed "tls data key_method wrong")
   in
   let pre_master = Cstruct.sub buf pre_master_start pre_master_len in


### PR DESCRIPTION
OpenVPN only checks the lower half of the key method in a key exchange message. It is unclear why and how the upper half might be used. I have not found any evidence the upper half has ever been used for anything other than zero bits.

Relevant OpenVPN code:
- https://github.com/OpenVPN/openvpn/blob/32e6586687a548174b88b64fe54bfae6c74d4c19/src/openvpn/ssl.h#L115-L116
- https://github.com/OpenVPN/openvpn/blob/32e6586687a548174b88b64fe54bfae6c74d4c19/src/openvpn/ssl.c#L2194-L2196