### PR TITLE
validate the hmac before processing the incoming control packet

### DIFF
--- a/miragevpn.opam
+++ b/miragevpn.opam
@@ -24,7 +24,7 @@ depends: [
   "logs"     { >= "0.6.2" }
 
   "angstrom" { >= "0.14.0" }
-  "cstruct"  { >= "6.0.0" }
+  "cstruct"  { >= "6.2.0" }
   "domain-name" { >= "0.2.0" }
   "fmt"
   "gmap"     { >= "0.3.0" }

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1739,7 +1739,7 @@ let validate_control state control_crypto op key payload =
         let key = Tls_crypt.Key.cipher_key their in
         Aes_ctr.decrypt ~key ~ctr encrypted
       in
-      let* to_be_signed =
+      let to_be_signed =
         Packet.Tls_crypt.to_be_signed op key cleartext decrypted
       in
       let computed_hmac =

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -86,7 +86,6 @@ let header session transport timestamp =
     { transport with last_acked_sequence_number },
     {
       Packet.local_session = session.my_session_id;
-      hmac = Cstruct.empty;
       replay_id;
       timestamp;
       ack_sequence_numbers;
@@ -97,10 +96,6 @@ let ptime_to_ts_exn now =
   match Ptime.(Span.to_int_s (to_span now)) with
   | None -> assert false (* this will break in 2038-01-19 *)
   | Some x -> Int32.of_int x
-
-let compute_hmac key p hmac_algorithm hmac_key =
-  let tbs = Packet.to_be_signed key p in
-  Mirage_crypto.Hash.mac hmac_algorithm ~key:hmac_key tbs
 
 let hmac_and_out protocol { hmac_algorithm; my_hmac; _ } key
     (p : [< Packet.ack | Packet.control ]) =
@@ -1124,7 +1119,7 @@ type error =
   | `Non_monotonic_sequence_number of int32 * int32
   | `Mismatch_their_session_id of int64 * int64
   | `Mismatch_my_session_id of int64 * int64
-  | `Bad_mac of t * Cstruct.t * Packet.t
+  | `Bad_mac of t * Cstruct.t * Cstruct.t * Cstruct.t
   | `No_transition of channel * Packet.operation * Cstruct.t
   | `No_channel of int
   | `Tls of
@@ -1147,9 +1142,10 @@ let pp_error ppf = function
   | `Mismatch_my_session_id (expected, received) ->
       Fmt.pf ppf "mismatched my session id: expected %016LX, received %016LX"
         expected received
-  | `Bad_mac (state, computed, data) ->
-      Fmt.pf ppf "bad mac: computed %a data %a@ (state %a)" Cstruct.hexdump_pp
-        computed Packet.pp data pp state
+  | `Bad_mac (state, computed, received, data) ->
+      Fmt.pf ppf "bad mac: computed %a received %a data %a@ (state %a)"
+        Cstruct.hexdump_pp computed Cstruct.hexdump_pp received
+        Cstruct.hexdump_pp data pp state
   | `No_transition (channel, op, data) ->
       Fmt.pf ppf "no transition found for typ %a (channel %a)@.data %a"
         Packet.pp_operation op pp_channel channel Cstruct.hexdump_pp data
@@ -1420,7 +1416,7 @@ let incoming_data ?(add_timestamp = false) err (ctx : keys) hmac_algorithm
         let hmac, data = Cstruct.split data H.digest_size in
         let computed_hmac = H.hmac ~key:their_hmac data in
         let* () =
-          guard (Cstruct.equal hmac computed_hmac) (err computed_hmac)
+          guard (Cstruct.equal hmac computed_hmac) (err hmac computed_hmac)
         in
         let iv, data = Cstruct.split data Cipher_block.AES.CBC.block_size in
         let dec = Cipher_block.AES.CBC.decrypt ~key:their_key ~iv data in
@@ -1699,7 +1695,7 @@ let find_channel state key op =
                 state);
           None)
 
-let received_data state key ch set_ch payload =
+let received_data state ch set_ch payload =
   let open Result.Syntax in
   match keys_opt ch with
   | None ->
@@ -1708,7 +1704,7 @@ let received_data state key ch set_ch payload =
   | Some keys ->
       let ch = received_packet ch payload in
       let hmac_algorithm = Config.get Auth state.config in
-      let bad_mac hmac = `Bad_mac (state, hmac, (key, `Data payload)) in
+      let bad_mac computed rcv = `Bad_mac (state, computed, rcv, payload) in
       let+ payload =
         incoming_data bad_mac keys hmac_algorithm state.session.compress payload
       in
@@ -1718,14 +1714,19 @@ let validate_control state control_crypto op key payload =
   let open Result.Syntax in
   match control_crypto with
   | `Tls_auth { hmac_algorithm; their_hmac; _ } ->
-      let hmac_len = Mirage_crypto.Hash.digest_size hmac_algorithm in
-      let* p = Packet.decode_ack_or_control op ~hmac_len payload in
-      let computed_mac = compute_hmac key p hmac_algorithm their_hmac in
-      let+ () =
-        guard
-          (Cstruct.equal computed_mac Packet.((header p).hmac))
-          (`Bad_mac (state, computed_mac, ((key, p) :> Packet.t)))
+      let hmac, tbs =
+        let hmac_len = Mirage_crypto.Hash.digest_size hmac_algorithm in
+        Packet.split_hmac hmac_len op key payload
       in
+      let computed_mac =
+        Mirage_crypto.Hash.mac hmac_algorithm ~key:their_hmac tbs
+      in
+      let* () =
+        guard
+          (Eqaf_cstruct.equal computed_mac hmac)
+          (`Bad_mac (state, computed_mac, hmac, tbs))
+      in
+      let+ p = Packet.decode_ack_or_control op tbs in
       (p, None)
   | `Tls_crypt ({ their; _ }, wkc_opt) ->
       let* cleartext, encrypted =
@@ -1738,25 +1739,27 @@ let validate_control state control_crypto op key payload =
         let key = Tls_crypt.Key.cipher_key their in
         Aes_ctr.decrypt ~key ~ctr encrypted
       in
+      let* to_be_signed =
+        Packet.Tls_crypt.to_be_signed op key cleartext decrypted
+      in
+      let computed_hmac =
+        let key = Tls_crypt.Key.hmac their in
+        Mirage_crypto.Hash.SHA256.hmac ~key to_be_signed
+      in
+      let* () =
+        guard
+          (Eqaf_cstruct.equal computed_hmac cleartext.hmac)
+          (`Bad_mac (state, computed_hmac, cleartext.hmac, to_be_signed))
+      in
       let* p =
         Packet.Tls_crypt.decode_decrypted_ack_or_control cleartext op decrypted
       in
-      let* needs_wkc =
+      let+ needs_wkc =
         match (p, wkc_opt) with
         | `Control (Packet.Hard_reset_server_v2, (_, _, data)), Some wkc ->
             let+ needs_wkc = Packet.decode_early_negotiation_tlvs data in
             if needs_wkc then Some wkc else None
         | _ -> Ok None
-      in
-      let to_be_signed = Packet.Tls_crypt.to_be_signed key p in
-      let computed_hmac =
-        let key = Tls_crypt.Key.hmac their in
-        Mirage_crypto.Hash.SHA256.hmac ~key to_be_signed
-      in
-      let+ () =
-        guard
-          (Eqaf_cstruct.equal computed_hmac cleartext.hmac)
-          (`Bad_mac (state, computed_hmac, ((key, p) :> Packet.t)))
       in
       (p, needs_wkc)
 
@@ -1795,8 +1798,7 @@ let incoming state control_crypto buf =
               match op with
               | Packet.Data_v1 ->
                   let+ state, payload =
-                    ignore_udp_error
-                      (received_data state key ch set_ch received)
+                    ignore_udp_error (received_data state ch set_ch received)
                   in
                   let payloads =
                     Option.fold payload ~none:payloads ~some:(fun p ->
@@ -2246,7 +2248,7 @@ let handle_static_client t s keys ev =
                   (* we don't need to check protocol as [`Tcp_partial] is only ever returned for tcp *)
                   Ok ({ t with linger }, acc)
               | Ok (cs, linger) ->
-                  let bad_mac hmac = `Bad_mac (t, hmac, (0, `Data cs)) in
+                  let bad_mac computed rcv = `Bad_mac (t, computed, rcv, cs) in
                   let* d =
                     incoming_data ~add_timestamp bad_mac keys hmac_algorithm
                       compress cs

--- a/src/packet.ml
+++ b/src/packet.ml
@@ -71,7 +71,6 @@ let guard f e = if f then Ok () else Error e
 
 type header = {
   local_session : int64;
-  hmac : Cstruct.t; (* usually 16 or 20 bytes *)
   replay_id : int32;
   timestamp : int32;
   (* uint8 array length *)
@@ -80,8 +79,8 @@ type header = {
 }
 
 let pp_header ppf hdr =
-  Fmt.pf ppf "local %Lu replay_id %ld timestamp %ld hmac %a ack %a remote %a"
-    hdr.local_session hdr.replay_id hdr.timestamp Cstruct.hexdump_pp hdr.hmac
+  Fmt.pf ppf "local %Lu replay_id %ld timestamp %ld ack %a remote %a"
+    hdr.local_session hdr.replay_id hdr.timestamp
     Fmt.(list ~sep:(any ", ") uint32)
     hdr.ack_sequence_numbers
     Fmt.(option ~none:(any " ") uint64)
@@ -89,38 +88,30 @@ let pp_header ppf hdr =
 
 let header = function `Ack hdr | `Control (_, (hdr, _, _)) -> hdr
 
-let decode_header ~hmac_len buf =
+let decode_header buf =
   let open Result.Syntax in
-  let* () = guard (Cstruct.length buf >= hdr_len hmac_len) `Partial in
-  let local_session = Cstruct.BE.get_uint64 buf 0
-  and hmac = Cstruct.sub buf 8 hmac_len
-  and replay_id = Cstruct.BE.get_uint32 buf (hmac_len + 8)
-  and timestamp = Cstruct.BE.get_uint32 buf (hmac_len + 12)
-  and arr_len = Cstruct.get_uint8 buf (hmac_len + 16) in
+  (* our input is a buffer where the hmac has already been swapped away *)
+  let* () = guard (Cstruct.length buf >= hdr_len 1) `Partial in
+  let replay_id = Cstruct.BE.get_uint32 buf 0
+  and timestamp = Cstruct.BE.get_uint32 buf 4
+  and local_session = Cstruct.BE.get_uint64 buf 9
+  and arr_len = Cstruct.get_uint8 buf 17 in
   let rs = if arr_len = 0 then 0 else 8 in
+  let hdr_off = hdr_len 1 in
   let+ () =
-    guard
-      (Cstruct.length buf >= hdr_len hmac_len + (id_len * arr_len) + rs)
-      `Partial
+    guard (Cstruct.length buf >= hdr_off + (id_len * arr_len) + rs) `Partial
   in
   let ack_sequence_number idx =
-    Cstruct.BE.get_uint32 buf (hdr_len hmac_len + (id_len * idx))
+    Cstruct.BE.get_uint32 buf (hdr_off + (id_len * idx))
   in
   let ack_sequence_numbers = List.init arr_len ack_sequence_number in
   let remote_session =
     if arr_len > 0 then
-      Some (Cstruct.BE.get_uint64 buf (hdr_len hmac_len + (id_len * arr_len)))
+      Some (Cstruct.BE.get_uint64 buf (hdr_off + (id_len * arr_len)))
     else None
   in
-  ( {
-      local_session;
-      hmac;
-      replay_id;
-      timestamp;
-      ack_sequence_numbers;
-      remote_session;
-    },
-    hdr_len hmac_len + (id_len * arr_len) + rs )
+  ( { local_session; replay_id; timestamp; ack_sequence_numbers; remote_session },
+    hdr_off + (id_len * arr_len) + rs )
 
 let encode_header hmac_len buf hdr =
   let id_arr_len = id_len * List.length hdr.ack_sequence_numbers in
@@ -141,74 +132,37 @@ let encode_header hmac_len buf hdr =
       Cstruct.BE.set_uint64 buf (hdr_len hmac_len + id_arr_len) v);
   hdr_len hmac_len + rsid + id_arr_len
 
-let to_be_signed_header ?(more = 0) op header =
-  (* replay_id ++ timestamp ++ operation ++ session_id ++ ack_len ++ acks ++ remote_session ++ sequence_number *)
-  let acks =
-    match header.ack_sequence_numbers with
-    | [] -> 0
-    | x -> List.length x * id_len
-  and rses = match header.remote_session with None -> 0 | Some _ -> 8 in
-  let buflen =
-    id_len + 4 (* timestamp *) + 1
-    (* operation *) + session_id_len
-    + 1 (* ack list length *) + acks
-    + rses + more
-  in
-  let buf = Cstruct.create buflen in
-  Cstruct.BE.set_uint32 buf 0 header.replay_id;
-  Cstruct.BE.set_uint32 buf 4 header.timestamp;
-  Cstruct.set_uint8 buf 8 op;
-  Cstruct.BE.set_uint64 buf 9 header.local_session;
-  Cstruct.set_uint8 buf 17 (List.length header.ack_sequence_numbers);
-  let rec enc_ack off = function
-    | [] -> ()
-    | hd :: tl ->
-        Cstruct.BE.set_uint32 buf off hd;
-        enc_ack (off + 4) tl
-  in
-  enc_ack 18 header.ack_sequence_numbers;
-  (match header.remote_session with
-  | None -> ()
-  | Some x -> Cstruct.BE.set_uint64 buf (18 + acks) x);
-  (buf, 18 + acks + rses)
-
-let decode_ack ~hmac_len buf =
+let decode_ack buf =
   let open Result.Syntax in
-  let+ hdr, off = decode_header ~hmac_len buf in
+  let+ hdr, off = decode_header buf in
   if off <> Cstruct.length buf then
     Log.debug (fun m ->
         m "decode_ack: %d extra bytes at end of message"
           (Cstruct.length buf - off));
   hdr
 
-let decode_control ~hmac_len buf =
+let decode_control buf =
   let open Result.Syntax in
-  let* header, off = decode_header ~hmac_len buf in
+  let* header, off = decode_header buf in
   let+ () = guard (Cstruct.length buf >= off + 4) `Partial in
   let sequence_number = Cstruct.BE.get_uint32 buf off
   and payload = Cstruct_ext.shift buf (off + 4) in
   (header, sequence_number, payload)
 
-let decode_ack_or_control op ~hmac_len buf =
+let decode_ack_or_control op buf =
   let open Result.Syntax in
   match op with
   | Ack ->
-      let+ ack = decode_ack ~hmac_len buf in
+      let+ ack = decode_ack buf in
       `Ack ack
   | _ ->
-      let+ control = decode_control ~hmac_len buf in
+      let+ control = decode_control buf in
       `Control (op, control)
 
 let encode_control hmac_len buf (header, sequence_number, payload) =
   let len = encode_header hmac_len buf header in
   Cstruct.BE.set_uint32 buf len sequence_number;
   Cstruct.blit payload 0 buf (len + 4) (Cstruct.length payload)
-
-let to_be_signed_control op (header, sequence_number, payload) =
-  (* rly? not length!? *)
-  let buf, off = to_be_signed_header ~more:id_len op header in
-  Cstruct.BE.set_uint32 buf off sequence_number;
-  Cstruct.append buf payload
 
 let decode_protocol proto buf =
   let open Result.Syntax in
@@ -258,6 +212,23 @@ let encode_protocol proto len =
       buf
   | `Udp -> Cstruct.empty
 
+let split_hmac hmac_len op key buf =
+  (* local_session_id ++ hmac, replay_id ++ ts ++ payload
+     -> (hmac, replay_id ++ ts ++ opcode ++ local_session_id ++ payload
+  *)
+  let local_session = Cstruct.BE.get_uint64 buf 0
+  (* below we modify the contents of buf, so we need to copy here *)
+  and hmac = Cstruct.sub_copy buf 8 hmac_len
+  and replay_id = Cstruct.BE.get_uint32 buf (hmac_len + 8)
+  and timestamp = Cstruct.BE.get_uint32 buf (hmac_len + 12) in
+  let to_cut = hmac_len - 1 (* - 1 (for key/op) *) in
+  let b = Cstruct.sub buf to_cut (Cstruct.length buf - to_cut) in
+  Cstruct.BE.set_uint32 b 0 replay_id;
+  Cstruct.BE.set_uint32 b 4 timestamp;
+  Cstruct.set_uint8 b 8 (op_key op key);
+  Cstruct.BE.set_uint64 b 9 local_session;
+  (hmac, b)
+
 let encode proto hmac_len
     (key, (p : [< `Ack of header | `Control of operation * _ ])) =
   let hdr = header p in
@@ -298,12 +269,6 @@ let encode_data buf proto key =
   let op = op_key Data_v1 key in
   Cstruct.set_uint8 buf (protocol_len proto) op
 
-let to_be_signed key p =
-  let op = op_key (operation p) key in
-  match p with
-  | `Ack hdr -> fst (to_be_signed_header op hdr)
-  | `Control (_, c) -> to_be_signed_control op c
-
 module Tls_crypt = struct
   type cleartext_header = {
     local_session : int64;
@@ -326,45 +291,32 @@ module Tls_crypt = struct
   let clear_hdr_len =
     hdr_len hmac_len - 1 (* not including acked sequence numbers *)
 
-  let to_be_signed_header ?(more = 0) op header =
-    (* op_key ++ session_id ++ replay_id ++ timestamp ++ ack_len ++ acks ++ remote_session ++ sequence_number *)
-    let acks_len = List.length header.ack_sequence_numbers * id_len
-    and rses_len = if Option.is_some header.remote_session then 8 else 0 in
-    let buflen =
-      1 (* operation *) + session_id_len
-      + id_len + 4 (* timestamp *) + 1
-      (* length of ack list *) + acks_len
-      + rses_len + more
+  let to_be_signed op key header decrypted =
+    let open Result.Syntax in
+    let+ bytes_to_use =
+      match op with
+      | Hard_reset_client_v3 ->
+          (* wkc is not part of the signed *)
+          let* () = guard (Cstruct.length decrypted > 1) `Partial in
+          let arr_len = Cstruct.get_uint8 decrypted 0 in
+          let byte_len =
+            1 (* arr_len *) + (arr_len * id_len)
+            (* acks *) + (if arr_len = 0 then 0 else 8)
+            (* remote session *) + 4 (* sequence number *)
+          in
+          let+ () = guard (Cstruct.length decrypted > byte_len) `Partial in
+          byte_len
+      | _ -> Ok (Cstruct.length decrypted)
     in
-    let buf = Cstruct.create buflen in
-    Cstruct.set_uint8 buf 0 op;
+    let hdr_len = hdr_len 0 in
+    let len = hdr_len + bytes_to_use in
+    let buf = Cstruct.create len in
+    Cstruct.set_uint8 buf 0 (op_key op key);
     Cstruct.BE.set_uint64 buf 1 header.local_session;
     Cstruct.BE.set_uint32 buf 9 header.replay_id;
     Cstruct.BE.set_uint32 buf 13 header.timestamp;
-    Cstruct.set_uint8 buf 17 (List.length header.ack_sequence_numbers);
-    let enc_ack idx ack = Cstruct.BE.set_uint32 buf (18 + (4 * idx)) ack in
-    List.iteri enc_ack header.ack_sequence_numbers;
-    Option.iter
-      (Cstruct.BE.set_uint64 buf (18 + acks_len))
-      header.remote_session;
-    (buf, 18 + acks_len + rses_len)
-
-  let to_be_signed_control op (header, sequence_number, payload) =
-    let buf, off =
-      to_be_signed_header op header ~more:(id_len + Cstruct.length payload)
-    in
-    Cstruct.BE.set_uint32 buf off sequence_number;
-    Cstruct.blit payload 0 buf (off + id_len) (Cstruct.length payload);
+    Cstruct.blit decrypted 0 buf hdr_len bytes_to_use;
     buf
-
-  let to_be_signed key p =
-    let op = op_key (operation p) key in
-    match p with
-    | `Ack hdr -> fst (to_be_signed_header op hdr)
-    | `Control (Hard_reset_client_v3, (hdr, sn, _wkc)) ->
-        (* HARD_RESET_CLIENT_V3 is special: the wkc is not considered part of the packet *)
-        to_be_signed_control op (hdr, sn, Cstruct.empty)
-    | `Control (_, c) -> to_be_signed_control op c
 
   let encode_header buf hdr =
     let acks_len = id_len * List.length hdr.ack_sequence_numbers in
@@ -444,13 +396,12 @@ module Tls_crypt = struct
         Some (Cstruct.BE.get_uint64 buf (1 + (id_len * arr_len)))
       else None
     in
-    let { local_session; replay_id; timestamp; hmac } = clear_hdr in
+    let { local_session; replay_id; timestamp; _ } = clear_hdr in
     let res =
       {
         local_session;
         replay_id;
         timestamp;
-        hmac;
         ack_sequence_numbers;
         remote_session;
       }


### PR DESCRIPTION
fixes #241

main branch:

```
╭────────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                    │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├────────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  Client/AES-128-GCM/decode data        │             0.0000 mjw/run│           413.6849 mnw/run│           1572.1415 ns/run│
│  Client/AES-128-GCM/encode data        │             0.0000 mjw/run│           188.6329 mnw/run│           1224.4682 ns/run│
│  Client/AES-256-CBC/decode data        │             0.0000 mjw/run│           413.5882 mnw/run│           1548.7285 ns/run│
│  Client/AES-256-CBC/encode data        │             0.0000 mjw/run│           188.5300 mnw/run│           1183.9394 ns/run│
│  Client/AES-256-GCM/decode data        │             0.0000 mjw/run│           413.7177 mnw/run│           1594.6786 ns/run│
│  Client/AES-256-GCM/encode data        │             0.0000 mjw/run│           188.6667 mnw/run│           1200.6835 ns/run│
│  Client/CHACHA20-POLY1305/decode data  │             0.0000 mjw/run│           413.8021 mnw/run│           1619.7392 ns/run│
│  Client/CHACHA20-POLY1305/encode data  │             0.0000 mjw/run│           188.7538 mnw/run│           1255.7042 ns/run│
╰────────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯
```

this PR:
```
╭────────────────────────────────────────┬───────────────────────────┬───────────────────────────┬───────────────────────────╮
│name                                    │  major-allocated          │  minor-allocated          │  monotonic-clock          │
├────────────────────────────────────────┼───────────────────────────┼───────────────────────────┼───────────────────────────┤
│  Client/AES-128-GCM/decode data        │             0.0000 mjw/run│           413.6912 mnw/run│           1518.6007 ns/run│
│  Client/AES-128-GCM/encode data        │             0.0000 mjw/run│           188.6438 mnw/run│           1167.6782 ns/run│
│  Client/AES-256-CBC/decode data        │             0.0000 mjw/run│           413.5976 mnw/run│           1504.1119 ns/run│
│  Client/AES-256-CBC/encode data        │             0.0000 mjw/run│           188.5455 mnw/run│           1189.6442 ns/run│
│  Client/AES-256-GCM/decode data        │             0.0000 mjw/run│           413.6977 mnw/run│           1506.7131 ns/run│
│  Client/AES-256-GCM/encode data        │             0.0000 mjw/run│           188.6550 mnw/run│           1215.5385 ns/run│
│  Client/CHACHA20-POLY1305/decode data  │             0.0000 mjw/run│           413.7853 mnw/run│           1558.7676 ns/run│
│  Client/CHACHA20-POLY1305/encode data  │             0.0000 mjw/run│           188.7389 mnw/run│           1183.3888 ns/run│
╰────────────────────────────────────────┴───────────────────────────┴───────────────────────────┴───────────────────────────╯
```