### PR TITLE
Control channel explicit exit notifications

### DIFF
--- a/app/miragevpn_client_lwt.ml
+++ b/app/miragevpn_client_lwt.ml
@@ -219,8 +219,9 @@ let handle_action conn = function
         Logs.warn (fun m -> m "connection cancelled by switch");
         match r with None -> Lwt.return_unit | Some x -> Common.safe_close x)
   | `Exit -> (* FIXME *) failwith "exit called"
-  | `Cc_exit | `Cc_halt | `Cc_restart ->
-      (* FIXME *) failwith "exit message received"
+  | (`Cc_exit | `Cc_halt _ | `Cc_restart _) as exit_msg ->
+      (* FIXME *)
+      Format.kasprintf failwith "%a received" Miragevpn.pp_action exit_msg
   | `Established (ip, mtu) ->
       Logs.app (fun m -> m "established %a" Miragevpn.pp_ip_config ip);
       Lwt_mvar.put conn.est_mvar (Ok (ip, mtu))

--- a/app/miragevpn_client_lwt.ml
+++ b/app/miragevpn_client_lwt.ml
@@ -218,7 +218,9 @@ let handle_action conn = function
       else (
         Logs.warn (fun m -> m "connection cancelled by switch");
         match r with None -> Lwt.return_unit | Some x -> Common.safe_close x)
-  | `Exit -> failwith "exit called"
+  | `Exit -> (* FIXME *) failwith "exit called"
+  | `Cc_exit | `Cc_halt | `Cc_restart ->
+      (* FIXME *) failwith "exit message received"
   | `Established (ip, mtu) ->
       Logs.app (fun m -> m "established %a" Miragevpn.pp_ip_config ip);
       Lwt_mvar.put conn.est_mvar (Ok (ip, mtu))

--- a/app/miragevpn_client_notun.ml
+++ b/app/miragevpn_client_notun.ml
@@ -206,7 +206,7 @@ let rec established_action proto fd incoming ifconfig tick client actions =
   | `Established _ ->
       Logs.err (fun m -> m "Unexpected action %a" pp_action action);
       assert false
-  | (`Cc_exit | `Cc_halt | `Cc_restart) as action ->
+  | (`Cc_exit | `Cc_halt _ | `Cc_restart _) as action ->
       Logs.warn (fun m -> m "Exiting due to received %a" pp_action action);
       let+ () = Common.safe_close fd in
       exit 0
@@ -254,7 +254,7 @@ and connected_action proto fd incoming tick client actions =
   | `Payload _ ->
       Logs.err (fun m -> m "Unexpected action %a" pp_action action);
       assert false
-  | (`Cc_exit | `Cc_halt | `Cc_restart) as action ->
+  | (`Cc_exit | `Cc_halt _ | `Cc_restart _) as action ->
       (* TODO: restart and exit should result in reconnect *)
       Logs.warn (fun m -> m "Exiting due to received %a" pp_action action);
       let+ () = Common.safe_close fd in
@@ -302,7 +302,7 @@ and connecting_action tick client actions =
       let* ev, k = connect in
       event k tick client actions ev
   | `Exit -> Lwt_result.fail (`Msg "Exiting due to Miragevpn engine exit")
-  | (`Cc_exit | `Cc_halt | `Cc_restart) as action ->
+  | (`Cc_exit | `Cc_halt _ | `Cc_restart _) as action ->
       Logs.warn (fun m -> m "Exiting due to received %a" pp_action action);
       exit 0
   | `Established _ | `Payload _ | `Transmit _ ->

--- a/app/miragevpn_client_notun.ml
+++ b/app/miragevpn_client_notun.ml
@@ -206,6 +206,10 @@ let rec established_action proto fd incoming ifconfig tick client actions =
   | `Established _ ->
       Logs.err (fun m -> m "Unexpected action %a" pp_action action);
       assert false
+  | (`Cc_exit | `Cc_halt | `Cc_restart) as action ->
+      Logs.warn (fun m -> m "Exiting due to received %a" pp_action action);
+      let+ () = Common.safe_close fd in
+      exit 0
   | (`Connect _ | `Resolve _) as action ->
       let* () = Common.safe_close fd in
       connecting_action tick client (action :: actions)
@@ -250,6 +254,11 @@ and connected_action proto fd incoming tick client actions =
   | `Payload _ ->
       Logs.err (fun m -> m "Unexpected action %a" pp_action action);
       assert false
+  | (`Cc_exit | `Cc_halt | `Cc_restart) as action ->
+      (* TODO: restart and exit should result in reconnect *)
+      Logs.warn (fun m -> m "Exiting due to received %a" pp_action action);
+      let+ () = Common.safe_close fd in
+      exit 0
   | (`Connect _ | `Resolve _) as action ->
       let* () = Common.safe_close fd in
       connecting_action tick client (action :: actions)
@@ -293,6 +302,9 @@ and connecting_action tick client actions =
       let* ev, k = connect in
       event k tick client actions ev
   | `Exit -> Lwt_result.fail (`Msg "Exiting due to Miragevpn engine exit")
+  | (`Cc_exit | `Cc_halt | `Cc_restart) as action ->
+      Logs.warn (fun m -> m "Exiting due to received %a" pp_action action);
+      exit 0
   | `Established _ | `Payload _ | `Transmit _ ->
       Logs.err (fun m -> m "Unexpected action %a" pp_action action);
       assert false

--- a/mirage/miragevpn_mirage.ml
+++ b/mirage/miragevpn_mirage.ml
@@ -463,9 +463,9 @@ struct
           Log.warn (fun m -> m "ignoring connection (cancelled by switch)");
           match r with None -> Lwt.return_unit | Some f -> TCP.close f)
     | `Exit -> (* FIXME *) failwith "exit called"
-    | (`Cc_exit | `Cc_restart | `Cc_halt) as _msg ->
+    | (`Cc_exit | `Cc_restart _ | `Cc_halt _) as exit_msg ->
         (* FIXME *)
-        failwith "exit message received"
+        Format.kasprintf failwith "%a received" Miragevpn.pp_action exit_msg
     | `Established (ip, mtu) ->
         Log.debug (fun m -> m "action = established");
         Lwt_mvar.put conn.est_mvar (ip, mtu)

--- a/mirage/miragevpn_mirage.ml
+++ b/mirage/miragevpn_mirage.ml
@@ -135,6 +135,12 @@ struct
         rm ();
         Log.info (fun m -> m "%a exiting" pp_dst dst);
         (None, `Stop)
+    | `Cc_exit ->
+        (* server does not produce [`Cc_halt] or [`Cc_restart] actions *)
+        rm ();
+        Log.info (fun m ->
+            m "%a exiting due to explicit exit notification" pp_dst dst);
+        (None, `Stop)
     | a ->
         Log.warn (fun m ->
             m "%a ignoring action %a" pp_dst dst Miragevpn.pp_action a);
@@ -456,7 +462,10 @@ struct
         else (
           Log.warn (fun m -> m "ignoring connection (cancelled by switch)");
           match r with None -> Lwt.return_unit | Some f -> TCP.close f)
-    | `Exit -> failwith "exit called"
+    | `Exit -> (* FIXME *) failwith "exit called"
+    | (`Cc_exit | `Cc_restart | `Cc_halt) as _msg ->
+        (* FIXME *)
+        failwith "exit message received"
     | `Established (ip, mtu) ->
         Log.debug (fun m -> m "action = established");
         Lwt_mvar.put conn.est_mvar (ip, mtu)

--- a/src/cc_message.ml
+++ b/src/cc_message.ml
@@ -1,0 +1,27 @@
+type cc_message = [ `Cc_restart | `Cc_halt | `Cc_exit ]
+
+(* OpenVPN is sloppy in its parsing and considers it a valid message if the
+   message just starts with {EXIT,HALT,RESTART}. We will not be as sloppy in
+   our parsing. *)
+let parse = function
+  | "EXIT\000" -> Some `Cc_exit
+  | "HALT\000" -> Some `Cc_halt
+  | "RESTART\000" -> Some `Cc_restart
+  | msg ->
+      if String.starts_with msg ~prefix:"RESTART," then
+        (* Ignoring message *)
+        Some `Cc_restart
+      else if String.starts_with msg ~prefix:"HALT," then
+        (* Ignoring message *)
+        Some `Cc_halt
+      else None
+
+let to_string = function
+  | `Cc_restart -> "RESTART\000"
+  | `Cc_halt -> "HALT\000"
+  | `Cc_exit -> "EXIT\000"
+
+let pp ppf = function
+  | `Cc_restart -> Fmt.string ppf "restart"
+  | `Cc_halt -> Fmt.string ppf "halt"
+  | `Cc_exit -> Fmt.string ppf "exit"

--- a/src/cc_message.ml
+++ b/src/cc_message.ml
@@ -1,27 +1,41 @@
-type cc_message = [ `Cc_restart | `Cc_halt | `Cc_exit ]
+type cc_message =
+  [ `Cc_restart of string option | `Cc_halt of string option | `Cc_exit ]
 
 (* OpenVPN is sloppy in its parsing and considers it a valid message if the
    message just starts with {EXIT,HALT,RESTART}. We will not be as sloppy in
    our parsing. *)
 let parse = function
   | "EXIT\000" -> Some `Cc_exit
-  | "HALT\000" -> Some `Cc_halt
-  | "RESTART\000" -> Some `Cc_restart
+  | "HALT\000" -> Some (`Cc_halt None)
+  | "RESTART\000" -> Some (`Cc_restart None)
   | msg ->
+      let get_message ~prefix msg =
+        let idx_start = String.length prefix in
+        let idx_end =
+          String.index_from_opt msg idx_start '\000'
+          |> Option.value ~default:(String.length msg)
+        in
+        String.sub msg idx_start (idx_end - idx_start)
+      in
       if String.starts_with msg ~prefix:"RESTART," then
-        (* Ignoring message *)
-        Some `Cc_restart
+        (* NOTE: For now we don't parse flags *)
+        let msg = get_message ~prefix:"RESTART," msg in
+        Some (`Cc_restart (Some msg))
       else if String.starts_with msg ~prefix:"HALT," then
-        (* Ignoring message *)
-        Some `Cc_halt
+        let msg = get_message ~prefix:"HALT," msg in
+        Some (`Cc_halt (Some msg))
       else None
 
 let to_string = function
-  | `Cc_restart -> "RESTART\000"
-  | `Cc_halt -> "HALT\000"
+  | `Cc_restart None -> "RESTART\000"
+  | `Cc_halt None -> "HALT\000"
+  | `Cc_restart (Some msg) -> "RESTART," ^ msg "\000"
+  | `Cc_halt (Some msg) -> "HALT," ^ msg ^ "\000"
   | `Cc_exit -> "EXIT\000"
 
 let pp ppf = function
-  | `Cc_restart -> Fmt.string ppf "restart"
-  | `Cc_halt -> Fmt.string ppf "halt"
+  | `Cc_restart None -> Fmt.string ppf "restart"
+  | `Cc_halt None -> Fmt.string ppf "halt"
+  | `Cc_restart (Some msg) -> Fmt.pf ppf "restart(%S)" msg
+  | `Cc_halt (Some msg) -> Fmt.pf ppf "halt(%S)" msg
   | `Cc_exit -> Fmt.string ppf "exit"

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -830,9 +830,7 @@ let incoming_control_client config rng session channel now op data =
       let+ tls', d = incoming_tls_without_reply tls data in
       let channel = { channel with channel_st = Established (tls', keys) } in
       let act =
-        match d with
-        | None -> None
-        | Some d -> (
+        Option.bind d (fun d ->
             let d = Cstruct.to_string d in
             match Cc_message.parse d with
             | Some msg -> Some msg

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1006,7 +1006,7 @@ let incoming_control_server is_not_taken config rng session channel _now _ts
             let d = Cstruct.to_string d in
             match Cc_message.parse d with
             | Some (`Cc_exit as msg) -> Some msg
-            | Some (`Cc_restart | `Cc_halt) ->
+            | Some (`Cc_restart _ | `Cc_halt _) ->
                 Log.info (fun m -> m "Received control message (ignored): %S" d);
                 None
             | None ->

--- a/src/miragevpn.mli
+++ b/src/miragevpn.mli
@@ -274,7 +274,10 @@ type initial_action =
   [ `Resolve of [ `host ] Domain_name.t * [ `Ipv4 | `Ipv6 | `Any ]
   | `Connect of Ipaddr.t * int * [ `Tcp | `Udp ] ]
 
-type action = [ initial_action | `Exit | `Established of ip_config * int ]
+type cc_message = [ `Cc_exit | `Cc_restart | `Cc_halt ]
+
+type action =
+  [ initial_action | `Exit | `Established of ip_config * int | cc_message ]
 
 val pp_action : action Fmt.t
 

--- a/src/miragevpn.mli
+++ b/src/miragevpn.mli
@@ -274,7 +274,8 @@ type initial_action =
   [ `Resolve of [ `host ] Domain_name.t * [ `Ipv4 | `Ipv6 | `Any ]
   | `Connect of Ipaddr.t * int * [ `Tcp | `Udp ] ]
 
-type cc_message = [ `Cc_exit | `Cc_restart | `Cc_halt ]
+type cc_message =
+  [ `Cc_exit | `Cc_restart of string option | `Cc_halt of string option ]
 
 type action =
   [ initial_action | `Exit | `Established of ip_config * int | cc_message ]

--- a/src/state.ml
+++ b/src/state.ml
@@ -139,7 +139,10 @@ type initial_action =
   [ `Resolve of [ `host ] Domain_name.t * [ `Ipv4 | `Ipv6 | `Any ]
   | `Connect of Ipaddr.t * int * [ `Tcp | `Udp ] ]
 
-type action = [ initial_action | `Exit | `Established of ip_config * int ]
+type cc_message = Cc_message.cc_message
+
+type action =
+  [ initial_action | `Exit | `Established of ip_config * int | cc_message ]
 
 let pp_ip_version ppf = function
   | `Ipv4 -> Fmt.string ppf "ipv4"
@@ -158,6 +161,8 @@ let pp_action ppf = function
   | `Exit -> Fmt.string ppf "exit"
   | `Established (ip, mtu) ->
       Fmt.pf ppf "established %a, mtu %d" pp_ip_config ip mtu
+  | (`Cc_exit | `Cc_restart | `Cc_halt) as msg ->
+      Fmt.pf ppf "control channel message %a" Cc_message.pp msg
 
 let ip_from_config config =
   match Config.(get Ifconfig config, get Route_gateway config) with

--- a/src/state.ml
+++ b/src/state.ml
@@ -161,7 +161,7 @@ let pp_action ppf = function
   | `Exit -> Fmt.string ppf "exit"
   | `Established (ip, mtu) ->
       Fmt.pf ppf "established %a, mtu %d" pp_ip_config ip mtu
-  | (`Cc_exit | `Cc_restart | `Cc_halt) as msg ->
+  | (`Cc_exit | `Cc_restart _ | `Cc_halt _) as msg ->
       Fmt.pf ppf "control channel message %a" Cc_message.pp msg
 
 let ip_from_config config =


### PR DESCRIPTION
- Parse better control channel messages

  Messages EXIT, RESTART and HALT are now better parsed. Messages RESTART and HALT can carry an optional message separated by a comma, e.g.

      HALT,shutting down

  The OpenVPN parser is very sloppy and only checks the prefixes "EXIT", "HALT", and "RESTART". Thus "HALTTTTT" is interpreted by OpenVPN as a HALT message. I chose not to be this sloppy with the parsing. I also chose not to attempt parsing the message for now. There are also potentially flags in the beginning of the message (only for RESTART according to the openvpn-rfc, but OpenVPN also parses it for HALT) - oddly they are not stripped from the message in OpenVPN. We can parse them at a later point if we so wish.

- Differentiate between `` `Exit `` actions triggered by e.g. timeouts and control channel messages.

The implementations are a bit too eager to exit. For `RESTART` (and maybe `EXIT`) we are expected to reconnect.