### PR TITLE
Some enhancements for the miragevpn_client_lwt

### DIFF
--- a/app/miragevpn_client_lwt.ml
+++ b/app/miragevpn_client_lwt.ml
@@ -15,7 +15,7 @@ let platform =
 
 let connected_ip = ref Ipaddr.V4.any
 
-let default_route dst =
+let remote_host_route dst =
   let dst = Ipaddr.V4.to_string dst in
   match Lazy.force platform with
   | Linux -> (
@@ -84,7 +84,7 @@ let open_tun config { Miragevpn.cidr; gateway } routes :
   let host_route =
     (* TODO: only if config includes redirect-gateway *)
     (* NOTE: this implements redirect-gateway autolocal *)
-    match default_route !connected_ip with
+    match remote_host_route !connected_ip with
     | None -> []
     | Some ip ->
         [

--- a/app/miragevpn_client_lwt.ml
+++ b/app/miragevpn_client_lwt.ml
@@ -13,6 +13,33 @@ let platform =
     | Ok s -> invalid_arg (Printf.sprintf "OS %s not supported" s)
     | Error (`Msg m) -> invalid_arg m)
 
+let connected_ip = ref Ipaddr.V4.any
+
+let default_route dst =
+  let dst = Ipaddr.V4.to_string dst in
+  match Lazy.force platform with
+  | Linux -> (
+      let cmd = Bos.Cmd.(v "ip" % "route" % "get" % dst) in
+      match Bos.OS.Cmd.(run_out cmd |> out_string |> success) with
+      | Ok routes -> (
+          match String.split_on_char ' ' routes with
+          | _ :: "via" :: ip :: _ -> Some ip
+          | _ -> None)
+      | Error (`Msg m) -> invalid_arg ("couldn't find default route " ^ m))
+  | FreeBSD -> (
+      let cmd = Bos.Cmd.(v "route" % "-n" % "show" % dst) in
+      match Bos.OS.Cmd.(run_out cmd |> out_lines |> success) with
+      | Ok lines -> (
+          match
+            List.find_opt
+              (fun l -> String.starts_with ~prefix:"gateway:" (String.trim l))
+              lines
+          with
+          | Some gw ->
+              Some (String.trim (List.nth (String.split_on_char ':' gw) 1))
+          | None -> None)
+      | Error (`Msg m) -> invalid_arg ("couldn't find default route " ^ m))
+
 let open_tun config { Miragevpn.cidr; gateway } routes :
     (Miragevpn.Config.t * Lwt_unix.file_descr, [> `Msg of string ]) result =
   (* This returns a Config with updated MTU, and a file descriptor for
@@ -54,6 +81,16 @@ let open_tun config { Miragevpn.cidr; gateway } routes :
     | Some _mtu -> (*Tuntap.set_mtu dev mtu TODO ; *) config
     | None -> Miragevpn.Config.add Tun_mtu (Tuntap.get_mtu dev) config
   in
+  let host_route =
+    (* TODO: only if config includes redirect-gateway *)
+    (* NOTE: this implements redirect-gateway autolocal *)
+    match default_route !connected_ip with
+    | None -> []
+    | Some ip ->
+        [
+          (Ipaddr.V4.Prefix.make 32 !connected_ip, Ipaddr.V4.of_string_exn ip, 0);
+        ]
+  in
   let* on_exit =
     match
       List.fold_left
@@ -73,7 +110,7 @@ let open_tun config { Miragevpn.cidr; gateway } routes :
           match Bos.OS.Cmd.run cmd_add with
           | Ok () -> Ok (cmd_del :: cmds_on_exit)
           | Error (`Msg m) -> Error (`Msg m, cmds_on_exit))
-        (Ok []) routes
+        (Ok []) (routes @ host_route)
     with
     | Ok cmds -> Ok cmds
     | Error (`Msg m, on_exit) ->
@@ -228,6 +265,9 @@ let handle_action conn = function
       connect_udp ip port >>= fun fd ->
       conn.peer <- Some (`Udp fd);
       Lwt.async (fun () -> reader_udp conn.event_mvar fd);
+      (match ip with
+      | Ipaddr.V4 ip -> connected_ip := ip
+      | Ipaddr.V6 _ -> Logs.warn (fun m -> m "ahhhh, v6"));
       Lwt_mvar.put conn.event_mvar `Connected
   | `Connect (ip, port, `Tcp) ->
       Lwt_switch.turn_off conn.est_switch >>= fun () ->
@@ -242,6 +282,9 @@ let handle_action conn = function
           | Some fd ->
               conn.peer <- Some (`Tcp fd);
               Lwt.async (fun () -> reader_tcp conn.event_mvar fd);
+              (match ip with
+              | Ipaddr.V4 ip -> connected_ip := ip
+              | Ipaddr.V6 _ -> Logs.warn (fun m -> m "aaaah"));
               `Connected
         in
         Lwt_mvar.put conn.event_mvar ev

--- a/app/miragevpn_client_lwt.ml
+++ b/app/miragevpn_client_lwt.ml
@@ -444,4 +444,8 @@ let cmd =
   and info = Cmd.info "miragevpn_client" ~version:"%%VERSION_NUM%%" in
   Cmd.v info term
 
-let () = exit (Cmd.eval cmd)
+let () =
+  try
+    Sys.catch_break true;
+    exit (Cmd.eval cmd)
+  with Sys.Break -> exit 1


### PR DESCRIPTION
There are 3 things:
- on FreeBSD, chop the 4 bytes header from tun_read, and add 4 bytes header on write
- add a host route to the VPN server using the old default gateway (this part has not been tested on Linux, please go ahead and do so)
- catch Ctrl-C and run at_exit on Ctrl-C

Hope this is in your interest :)