### PR TITLE
Compute routes with net_gateway or remote_host

### DIFF
--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1936,10 +1936,9 @@ let incoming state control_crypto buf =
                       | Some (`Established ip_config) ->
                           let state = { state with channel = ch } in
                           let+ state, mtu = transition_to_established state in
-                          let routes = Config_ext.routes config in
                           let est =
                             Option.map
-                              (fun mtu -> `Established (ip_config, mtu, routes))
+                              (fun mtu -> `Established (ip_config, mtu, config))
                               mtu
                           in
                           let act =
@@ -2287,9 +2286,8 @@ let handle_static_client t s keys ev =
           let my_ip, their_ip = Config.get Ifconfig t.config in
           let mtu = data_mtu t.config t.session in
           let cidr = Ipaddr.V4.Prefix.make 32 my_ip in
-          let routes = Config_ext.routes t.config in
           let est =
-            `Established ({ Config_ext.cidr; gateway = their_ip }, mtu, routes)
+            `Established ({ Config_ext.cidr; gateway = their_ip }, mtu, t.config)
           in
           let protocol = match remote idx with _, _, proto -> proto in
           let session = { t.session with protocol } in

--- a/src/miragevpn.mli
+++ b/src/miragevpn.mli
@@ -244,6 +244,7 @@ type t
 
 type server
 type ip_config = { cidr : Ipaddr.V4.Prefix.t; gateway : Ipaddr.V4.t }
+type route_info
 
 val pp_ip_config : ip_config Fmt.t
 val server_bind_port : Config.t -> int
@@ -257,6 +258,13 @@ val remotes :
   list
 
 val proto : Config.t -> [ `Any | `Ipv4 | `Ipv6 ] * [ `Udp | `Tcp ]
+
+val routes :
+  shares_subnet:bool ->
+  net_gateway:Ipaddr.V4.t option ->
+  remote_host:Ipaddr.V4.t option ->
+  route_info ->
+  (Ipaddr.V4.Prefix.t * Ipaddr.V4.t * int) list
 
 type event =
   [ `Resolved of Ipaddr.t
@@ -278,8 +286,7 @@ type cc_message =
 type action =
   [ initial_action
   | `Exit
-  | `Established of
-    ip_config * int * (Ipaddr.V4.Prefix.t * Ipaddr.V4.t * int) list
+  | `Established of ip_config * int * route_info
   | cc_message ]
 
 val pp_action : action Fmt.t

--- a/src/state.ml
+++ b/src/state.ml
@@ -114,6 +114,8 @@ let set_keys ch keys =
   in
   { ch with channel_st }
 
+type route_info = Config.t
+
 type event =
   [ `Resolved of Ipaddr.t
   | `Resolve_failed
@@ -139,8 +141,7 @@ type cc_message = Cc_message.cc_message
 type action =
   [ initial_action
   | `Exit
-  | `Established of
-    Config_ext.ip_config * int * (Ipaddr.V4.Prefix.t * Ipaddr.V4.t * int) list
+  | `Established of Config_ext.ip_config * int * route_info
   | cc_message ]
 
 let pp_ip_version ppf = function
@@ -158,15 +159,8 @@ let pp_action ppf = function
   | `Connect (ip, port, proto) ->
       Fmt.pf ppf "connect %a %a:%d" pp_proto proto Ipaddr.pp ip port
   | `Exit -> Fmt.string ppf "exit"
-  | `Established (ip, mtu, routes) ->
-      let pp_route ppf (net, gw, metric) =
-        Fmt.pf ppf "%a via %a metric %u" Ipaddr.V4.Prefix.pp net Ipaddr.V4.pp gw
-          metric
-      in
-      Fmt.pf ppf "established %a, mtu %d, routes %a" Config_ext.pp_ip_config ip
-        mtu
-        Fmt.(list ~sep:(any ", ") pp_route)
-        routes
+  | `Established (ip, mtu, _route_info) ->
+      Fmt.pf ppf "established %a, mtu %d" Config_ext.pp_ip_config ip mtu
   | (`Cc_exit | `Cc_restart _ | `Cc_halt _) as msg ->
       Fmt.pf ppf "control channel message %a" Cc_message.pp msg
 


### PR DESCRIPTION
And attempt autolocal.

Instead of the `` `Established _ `` action returning a list of routes it returns an opaque object of type `route_info` which under the hood is `Config.t`. Then the client of the engine can call `Miragevpn.routes` passing the `route_info` as well as some required information on the remote host ip and routing table. This way we can resolve magic keywords `net_gateway` and `remote_host` in `--route` directives, and we attempt to figure out `autolocal`. We also respect the `local` flag in `--redirect-gateway` if present.

I learnt that OpenVPN discards routes which it can't resolve, for example a `--route` with `net_gateway` on an IPv6-only host. Thus I decided to warn and skip such routes. The `net_gateway` and `remote_host` are `Ipaddr.V4.t option`s in case of IPv6.

Certainly the route detection in miragevpn-client-lwt could be made more robust.