### PR TITLE
Bump cmdliner version constraint

### DIFF
--- a/miragevpn.opam
+++ b/miragevpn.opam
@@ -55,7 +55,7 @@ depends: [
   "mirage-random" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   # tooling:
-  "cmdliner" { >= "1.1.0" }
+  "cmdliner" { >= "1.3.0" }
   "hxd"
   "bos"
 


### PR DESCRIPTION
Due to usage of Cmdliner.Term.Syntax introduced in 4d96f2bdebfe53ff6b97b152292403c14adc5dc7 which is new in cmdliner.1.3.0.