### PR TITLE
avoid cmdliner 1.3.0 dependency

### DIFF
--- a/app/openvpn_config_parser.ml
+++ b/app/openvpn_config_parser.ml
@@ -108,14 +108,15 @@ let client =
   Arg.(value & flag & info [ "client" ] ~doc)
 
 let mode =
-  let open Term.Syntax in
-  let+ client = client and+ server = server in
-  match (client, server) with
-  | true, true ->
-      Printf.eprintf "Can't check both --server and --client\n%!";
-      exit Cmd.Exit.cli_error
-  | false, true -> `Server
-  | (false | true), false -> `Client
+  let f client server =
+    match (client, server) with
+    | true, true ->
+        Printf.eprintf "Can't check both --server and --client\n%!";
+        exit Cmd.Exit.cli_error
+    | false, true -> `Server
+    | (false | true), false -> `Client
+  in
+  Term.(const f $ client $ server)
 
 let block_size =
   let pos_int =

--- a/miragevpn.opam
+++ b/miragevpn.opam
@@ -55,7 +55,7 @@ depends: [
   "mirage-random" {>= "2.0.0"}
   "mirage-clock" {>= "3.0.0"}
   # tooling:
-  "cmdliner" { >= "1.3.0" }
+  "cmdliner" { >= "1.1.0" }
   "hxd"
   "bos"
 


### PR DESCRIPTION
reason is https://github.com/dune-universe/opam-overlays/issues/215