### PR TITLE
Various optimizations

### DIFF
--- a/bench/bench_engine.ml
+++ b/bench/bench_engine.ml
@@ -194,7 +194,7 @@ let test_receive_data cipher =
     Staged.stage @@ fun () ->
     match Miragevpn.handle established_client (`Data pkt) with
     | Ok _ -> ()
-    | Error _ -> assert false
+    | Error err -> Format.kasprintf failwith "%a" Miragevpn.pp_error err
   in
   Test.make ~name:"decode data" staged
 

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -2246,7 +2246,12 @@ let handle_static_client t s keys ev =
               | Error `Tcp_partial ->
                   (* we don't need to check protocol as [`Tcp_partial] is only ever returned for tcp *)
                   Ok ({ t with linger }, acc)
-              | Ok (cs, linger) ->
+              | Ok (poff, plen) ->
+                  let cs, linger =
+                    ( String.sub linger poff plen,
+                      String.sub linger (poff + plen)
+                        (String.length linger - poff - plen) )
+                  in
                   let bad_mac computed rcv = `Bad_mac (t, computed, rcv, cs) in
                   let* d =
                     incoming_data ~add_timestamp bad_mac keys hmac_algorithm

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1147,7 +1147,7 @@ let out ?add_timestamp prefix_len (ctx : keys) hmac_algorithm compress rng data
       Bytes.create
         (prefix_len + String.length replay_id + tag_size + String.length data)
     in
-    Bytes.blit_string replay_id 0 b prefix_len (String.length replay_id);
+    set_replay_id b prefix_len;
     authenticate_encrypt_into ~key:my_key ~nonce ~adata:replay_id data
       ~src_off:0 b
       ~dst_off:(prefix_len + String.length replay_id + tag_size)

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1191,6 +1191,7 @@ let out ?add_timestamp prefix_len (ctx : keys) hmac_algorithm compress rng data
           Bytes.create
             (prefix_len + H.digest_size + String.length iv + String.length data)
         in
+        Bytes.blit_string iv 0 b (prefix_len + H.digest_size) (String.length iv);
         AES.CBC.encrypt_into ~key:my_key ~iv data ~src_off:0 b
           ~dst_off:(prefix_len + H.digest_size + String.length iv)
           (String.length data);
@@ -1199,7 +1200,6 @@ let out ?add_timestamp prefix_len (ctx : keys) hmac_algorithm compress rng data
         in
         (* H.get_into_bytes hmac ~off:prefix_len b; *)
         Bytes.blit_string (H.to_raw_string hmac) 0 b prefix_len H.digest_size;
-        Bytes.blit_string iv 0 b (prefix_len + H.digest_size) (String.length iv);
         b
     | AES_GCM { my_key; my_implicit_iv; _ } ->
         aead Mirage_crypto.AES.GCM.tag_size

--- a/src/engine.ml
+++ b/src/engine.ml
@@ -1400,7 +1400,7 @@ let incoming_data ?(add_timestamp = false) err (ctx : keys) hmac_algorithm
         Log.debug (fun m ->
             m "received replay packet id is %lu" (String.get_int32_be dec 0));
         (* TODO validate ts if provided (avoid replay) *)
-        unpad AES.CBC.block_size dec off
+        unpad AES.CBC.block_size dec hdr_len
     | AES_GCM { their_key; their_implicit_iv; _ } ->
         let tag_len = Mirage_crypto.AES.GCM.tag_size in
         let* () =

--- a/src/packet.ml
+++ b/src/packet.ml
@@ -174,18 +174,21 @@ let decode_protocol proto buf =
       let* () = guard (String.length buf >= 2) `Tcp_partial in
       let plen = String.get_uint16_be buf 0 in
       let+ () = guard (String.length buf - 2 >= plen) `Tcp_partial in
-      ( String.sub buf 2 plen,
-        String.sub buf (plen + 2) (String.length buf - plen - 2) )
-  | `Udp -> Ok (buf, "")
+      (2, plen)
+  | `Udp -> Ok (0, String.length buf)
 
 let decode_key_op proto buf =
   let open Result.Syntax in
-  let* buf, linger = decode_protocol proto buf in
-  let* () = guard (String.length buf >= 1) `Partial in
-  let opkey = String.get_uint8 buf 0 in
+  let* poff, plen = decode_protocol proto buf in
+  let* () = guard (plen >= 1) `Partial in
+  let opkey = String.get_uint8 buf poff in
   let op, key = (opkey lsr 3, opkey land 0x07) in
   let+ op = int_to_operation op in
-  (op, key, String.sub buf 1 (String.length buf - 1), linger)
+  let buf, linger =
+    ( String.sub buf (poff + 1) (plen - 1),
+      String.sub buf (poff + plen) (String.length buf - poff - plen) )
+  in
+  (op, key, buf, linger)
 
 let operation = function
   | `Ack _ -> Ack


### PR DESCRIPTION
These are mostly optimizations from https://github.com/robur-coop/miragevpn/pull/223 but also some new ones since we have encrypt_into etc. functions.

`main-bench.exe` is built from 6099a4bd4134eedddd16090a083dc58d246eeae1 (unfortunately without --release)
![image](https://github.com/user-attachments/assets/57fb1a27-a6e5-4fce-bf6b-bcb461336b1c)

As you can see above there are improvements in execution time, but most notably the number of minor words allocations is almost halved. When testing against an openvpn server I didn't observe much of a difference except, curiously, a slowdown in upload speed (from 826 Mb/s to 757 Mb/s). Why that would I don't know.